### PR TITLE
Fix for panels not working with files with spaces

### DIFF
--- a/git.py
+++ b/git.py
@@ -409,7 +409,7 @@ class GitAddChoiceCommand(GitStatusCommand):
     def panel_followup(self, picked_file, picked_index):
         if picked_index == 0:
             picked_file = '.'
-        self.run_command(['git', 'add', picked_file],
+        self.run_command(['git', 'add', "--", picked_file.strip('"')],
             working_dir=git_root(self.get_file_location()))
 
 


### PR DESCRIPTION
This change fixes a problem I found where files with spaces wouldn't be handled properly by the panels for `status` and `add...`
