### PR TITLE
Package directory is configurable

### DIFF
--- a/git.py
+++ b/git.py
@@ -46,6 +46,14 @@ def _make_text_safeish(text, fallback_encoding):
     return unitext
 
 
+def syntax_file(language, view):
+    return os.path.join(
+        sublime.packages_path(),
+        view.settings().get('git_package_dir') or 'Git',
+        language + ".tmLanguage"
+    )
+
+
 class CommandThread(threading.Thread):
     def __init__(self, command, on_done, working_dir="", fallback_encoding=""):
         threading.Thread.__init__(self)
@@ -212,8 +220,7 @@ class GitLogCommand(GitCommand):
             self.details_done)
 
     def details_done(self, result):
-        print os.getcwd()
-        self.scratch(result, title="Git Commit Details", syntax="Git Commit Message.tmLanguage")
+        self.scratch(result, title="Git Commit Details", syntax=syntax_file("Git Commit Message", self.view))
 
 
 class GitLogAllCommand(GitLogCommand):
@@ -230,7 +237,7 @@ class GitGraphCommand(GitCommand):
         )
 
     def log_done(self, result):
-        self.scratch(result, title="Git Log Graph", syntax="Git Graph.tmLanguage")
+        self.scratch(result, title="Git Log Graph", syntax=syntax_file('Git Graph', self.view))
 
 
 class GitGraphAllCommand(GitGraphCommand):
@@ -327,7 +334,8 @@ class GitCommitCommand(GitCommand):
         msg = self.window().new_file()
         msg.set_scratch(True)
         msg.set_name("COMMIT_EDITMSG")
-        self._output_to_view(msg, template, syntax="Git Commit Message.tmLanguage")
+
+        self._output_to_view(msg, template, syntax=syntax_file("Git Commit Message", self.view))
         msg.sel().clear()
         msg.sel().add(sublime.Region(0, 0))
         GitCommitCommand.active_message = self


### PR DESCRIPTION
I've changed the parts of the plugin which load the language syntax files to read a setting called `git_package_dir` and use that as the directory to load from. This is relative to the packages folder.

For example, if you have the plugin installed in `/path/to/Packages/sublime-text-2-git`, then you should change `Base File.sublime-settings` to add this:

``` javascript
{
    "git_package_dir": "sublime-text-2-git"
}
```

The default value is `"Git"`, so if the plugin was installed via Package Control, you do not need to do anything.

> **Note**: I'm a total newbie with python, and I wasn't able to find any information about how to get the file system path of the currently-executing module, hence the hack workaround with using settings. If someone else knows a better way, please do let me know.
