### PR TITLE
"Quick Commit" menu item now calls the correct command.

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -14,7 +14,7 @@
                             { "caption": "Log", "command": "git_log" }
                             ,{ "caption": "Diff", "command": "git_diff" }
                             ,{ "caption": "Add", "command": "git_add" }
-                            ,{ "caption": "Quick Commit", "command": "git_commit" }
+                            ,{ "caption": "Quick Commit", "command": "git_quick_commit" }
                             ,{ "caption": "Blame", "command": "git_blame" }
                             ,{ "caption": "Checkout", "command": "git_checkout" }
                             ,{ "caption": "Graph", "command": "git_graph" }


### PR DESCRIPTION
The "This File" > "Quick Commit" menu item was incorrectly calling the git_commit command. This fix switches it to the appropriate git_quick_commit command instead.

Tested on my local copy and everything looked good.
