### PR TITLE
Fixing commit with more than one git repo

### DIFF
--- a/git.py
+++ b/git.py
@@ -362,6 +362,7 @@ class GitCommitCommand(GitWindowCommand):
     active_message = False
 
     def run(self):
+        self.working_dir = self.get_working_dir()
         self.run_command(
             ['git', 'status', '--untracked-files=no', '--porcelain'],
             self.porcelain_status_done
@@ -409,7 +410,7 @@ class GitCommitCommand(GitWindowCommand):
         self.message_file = message_file
         # and actually commit
         self.run_command(['git', 'commit', '-F', message_file.name],
-            self.commit_done)
+            self.commit_done, working_dir=self.working_dir)
 
     def commit_done(self, result):
         os.remove(self.message_file.name)


### PR DESCRIPTION
I have more than one folder with git repository in sublime tree (build 2126). If I try to commit to any repository, sublime-git send the commit command to the first folder, because when on_close happens sublime doesn't have a active view.

I solved the bug with two git projects in sublime tree and sublime-git wasn't the first one. I wouldn't be able to commit to sublime-git if I hadn't solved the issue. :)
