### PR TITLE
git diff with marks

### DIFF
--- a/git.py
+++ b/git.py
@@ -309,7 +309,12 @@ class GitDiff (object):
         if not result.strip():
             self.panel("No output")
             return
-        self.scratch(result, title="Git Diff")
+        view = self.scratch(result, title="Git Diff")
+        lines_inserted = view.find_all(r'^\+[^+]{2} ')
+        lines_deleted = view.find_all(r'^-[^-]{2} ')
+
+        view.add_regions("inserted", lines_inserted, "markup.inserted.diff", "dot", sublime.HIDDEN)
+        view.add_regions("deleted", lines_deleted, "markup.deleted.diff", "dot", sublime.HIDDEN)
 
 
 class GitDiffCommand(GitDiff, GitTextCommand):


### PR DESCRIPTION
Related to kemayo/sublime-text-2-git#32.

It is a first attempt to show git diff with marks. It show lines inserted or removed.

I opened a pull request just to discuss how to handle it.

I guess we can add `--word-diff=plain` to `git diff` command, so we are able to parse it in a nice way, adding lines edited too and removing the +/- signs in lines added/removed.

![git diff with marks](http://dl.dropbox.com/u/3448392/sublime-git-diff-marks.png)
