### PR TITLE
Make sure active file view is updated

### DIFF
--- a/git.py
+++ b/git.py
@@ -118,7 +118,7 @@ class GitCommand:
     def generic_done(self, result):
         if not result.strip():
             return
-        self.panel(result)
+        self.scratch(result)
 
     def _output_to_view(self, output_file, output, clear=False,
             syntax="Packages/Diff/Diff.tmLanguage"):


### PR DESCRIPTION
When switching between branches or pulling new updates, the active file view is not updated until you switch between windows.

I made the general_done function open a scratch window instead just to force the view update. Might be a better way to do this but I haven't found it.
