### PR TITLE
Added option to toggle --verbose style commit messages

### DIFF
--- a/Git.sublime-settings
+++ b/Git.sublime-settings
@@ -5,4 +5,7 @@
 	// if present, use this command instead of plain "git"
 	// e.g. "/Users/kemayo/bin/git" or "C:\bin\git.exe"
 	,"git_command": false
+
+    // Use --verbose flag for commit messages
+    ,"verbose_commits": true
 }

--- a/git.py
+++ b/git.py
@@ -391,7 +391,12 @@ class GitCommitCommand(GitWindowCommand):
             self.panel("Nothing to commit")
             return
         # Okay, get the template!
-        self.run_command(['git', 'diff', '--staged'], self.diff_done)
+        s = sublime.load_settings("Git.sublime-settings")
+        if s.get("verbose_commits"):
+            self.run_command(['git', 'diff', '--staged'], self.diff_done)
+        else:
+            self.run_command(['git', 'status'], self.diff_done)
+
 
     def diff_done(self, result):
         template = "\n".join([
@@ -410,6 +415,7 @@ class GitCommitCommand(GitWindowCommand):
         msg.sel().clear()
         msg.sel().add(sublime.Region(0, 0))
         GitCommitCommand.active_message = self
+
 
     def message_done(self, message):
         # filter out the comments (git commit doesn't do this automatically)


### PR DESCRIPTION
This fixes #Num: #65.

Adds a setting that lets people use either --verbose style commit messages (the default, as introduced by 442b357), or the older, _"regular"_ style.
