### PR TITLE
Added setting allowing 'Git: Status' to open files

### DIFF
--- a/Git.sublime-settings
+++ b/Git.sublime-settings
@@ -13,4 +13,8 @@
 	// true: blame whole file
 	// false: blame only current line
 	,"blame_whole_file": true
+	// If you'd rather have your status command open files instead of show you a
+	// diff, set this to true.  You can still do `Git: Status` followed by
+	// 'Git: Diff Current File' to get a file diff
+	,"status_opens_file": false
 }

--- a/git.py
+++ b/git.py
@@ -577,8 +577,9 @@ class GitStatusCommand(GitWindowCommand):
     def panel_followup(self, picked_status, picked_file, picked_index):
         # split out solely so I can override it for laughs
 
+        s = sublime.load_settings("Git.sublime-settings")
         root = git_root(self.get_working_dir())
-        if picked_status == '??':
+        if picked_status == '??' or s.get('status_opens_file'):
             self.window.open_file(os.path.join(root, picked_file))
         else:
             self.run_command(['git', 'diff', '--no-color', '--', picked_file.strip('"')],


### PR DESCRIPTION
One of the biggest issues I'd have with the Git plugin
was that there was no easy way to get to files you've
been working on.  For instance, when resolving merge
conflicts, or picking up after switching projects.
Enabling this option lets you quickly open modified files,
conflicts and such.
