### PR TITLE
easier adding of multiple files

### DIFF
--- a/git.py
+++ b/git.py
@@ -617,8 +617,11 @@ class GitAddChoiceCommand(GitStatusCommand):
         else:
             args = ["--", picked_file.strip('"')]
 
-        self.run_command(['git', 'add'] + args,
+        self.run_command(['git', 'add'] + args, self.rerun,
             working_dir=git_root(self.get_working_dir()))
+
+    def rerun(self, result):
+        self.run()
 
 
 class GitAdd(GitTextCommand):


### PR DESCRIPTION
rerun add after adding a file from the add choice quick panel. this
allows a quick way to add mutliple files without adding them all.
you can still cancel the panel by pressing escape.
