### PR TITLE
open modified files

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -48,6 +48,10 @@
         "command": "git_status"
     }
     ,{
+        "caption": "Git: Open Modified Files",
+        "command": "git_open_modified_files"
+    }
+    ,{
         "caption": "Git: New Branch",
         "command": "git_new_branch"
     }

--- a/git.py
+++ b/git.py
@@ -592,8 +592,8 @@ class GitStatusCommand(GitWindowCommand):
 
         s = sublime.load_settings("Git.sublime-settings")
         root = git_root(self.get_working_dir())
-        if picked_status == '??' or s.get('status_opens_file'):
-            self.window.open_file(os.path.join(root, picked_file))
+        if picked_status == '??' or s.get('status_opens_file') or self.force_open:
+            if(os.path.isfile(picked_file)): self.window.open_file(os.path.join(root, picked_file))
         else:
             self.run_command(['git', 'diff', '--no-color', '--', picked_file.strip('"')],
                 self.diff_done, working_dir=root)
@@ -603,6 +603,12 @@ class GitStatusCommand(GitWindowCommand):
             return
         self.scratch(result, title="Git Diff")
 
+class GitOpenModifiedFilesCommand(GitStatusCommand):
+    force_open = True
+
+    def show_status_list(self):
+        for line_index in range(0, len(self.results)):
+            self.panel_done(line_index)
 
 class GitAddChoiceCommand(GitStatusCommand):
     def status_filter(self, item):


### PR DESCRIPTION
new command that opens all modified files. anything not committed
should open.

I find it useful to open all the modified files when doing commits per-hunk. So I can scroll through each file and add the hunks I want, and then commit without having to open each file from status manually. What do you think, worth a pull into mainline? 
