### PR TITLE
Fix windows annotations

### DIFF
--- a/git.py
+++ b/git.py
@@ -133,7 +133,7 @@ class CommandThread(threading.Thread):
             main_thread(self.on_done, e.returncode)
         except OSError, e:
             if e.errno == 2:
-                main_thread(sublime.error_message, "Git binary could not be found in PATH\n\nConsider using the git_command setting for the Git plugin\n\nPATH is: %s" % os.environ['PATH'])
+                main_thread(sublime.error_message, "Git binary (%s) could not be found in PATH\n\nConsider using the git_command setting for the Git plugin\n\nPATH is: %s" % (self.command[0], os.environ['PATH']))
             else:
                 raise e
 


### PR DESCRIPTION
Windows doesn't allow other programs to read files created with `tempfile.NamedTemporaryFile(delete=True)`. That's why we get something like:

```
Exception in thread Thread-173:
Traceback (most recent call last):
  File ".\threading.py", line 532, in __bootstrap_inner
  File ".\git.py", line 96, in run
  File ".\subprocess.py", line 701, in communicate
  File ".\subprocess.py", line 911, in _communicate
IOError: [Errno 32] Broken pipe
```

Also, `diff` is usually not installed on windows. One of these commits tells the user about this.

Side note: It would be cool if the checks for the existence of external programs could be done in some initialisation part of the plugin, like in the [detection phase of SublimeLinter](https://github.com/SublimeLinter/SublimeLinter/blob/9de381a137174e009b053e8ab7ccef4e3bdbbdea/sublimelinter/modules/base_linter.py#L114).
