### PR TITLE
global annotations

### DIFF
--- a/git.py
+++ b/git.py
@@ -173,6 +173,8 @@ class GitCommand(object):
                 do_when(lambda: not self.active_view().is_loading(), lambda: self.active_view().set_viewport_position(position, False))
                 # self.active_view().show(position)
 
+        self.view.run_command('git_annotate')
+
         if not result.strip():
             return
         self.panel(result)
@@ -1045,9 +1047,9 @@ class GitToggleAnnotationsCommand(GitTextCommand):
 
 class GitAnnotationListener(sublime_plugin.EventListener):
     def on_modified(self, view):
-        if not view.settings().get('live_git_annotations'):
-            return
         view.run_command('git_annotate')
+    def on_load(self, view):
+        self.on_modified(view)
 
 
 class GitAnnotateCommand(GitTextCommand):
@@ -1064,7 +1066,6 @@ class GitAnnotateCommand(GitTextCommand):
             self.compare_tmp(None)
             return
         self.tmp = tempfile.NamedTemporaryFile()
-        self.active_view().settings().set('live_git_annotations', True)
         root = git_root(self.get_working_dir())
         repo_file = os.path.relpath(self.view.file_name(), root)
         self.run_command(['git', 'show', 'HEAD:{0}'.format(repo_file)], show_status=False, no_save=True, callback=self.compare_tmp, stdout=self.tmp)


### PR DESCRIPTION
first attempt at global annotations, seems to work ok but the
annotation code is quite slow on callback, need a better way to run
the diffs as often as we can without slowing down typing,
asynchronously as fast as we can would be better than on every change
