### PR TITLE
Show git status in Sublime Text 2 status bar

### DIFF
--- a/Git.sublime-settings
+++ b/Git.sublime-settings
@@ -33,4 +33,7 @@
 
 	// Annotations default to being on for all files. Can be slow in some cases.
 	,"annotations": false
+
+	// Symbols for quick git status in status bar
+	,"status_symbols" : {"modified": "≠", "added": "+", "deleted": "×", "untracked": "?", "conflicts": "‼", "clean": "√", "separator": " "}
 }


### PR DESCRIPTION
Show git status in Sublime Text 2 status bar in a quick and simple way (e.g. one file added, five untracked is shown as 1+ 5?).

Configure status symbols in settings parameter "status_symbols". Added hook after document save to refresh status.
