### PR TITLE
Enable Diff Tool Current File, and Diff Tool All

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -47,8 +47,12 @@
         "command": "git_diff_commit"
     }
     ,{
-        "caption": "Git: Diff Tool",
+        "caption": "Git: Diff Tool Current File",
         "command": "git_diff_tool"
+    }
+    ,{
+        "caption": "Git: Diff Tool All",
+        "command": "git_diff_tool_all"
     }
     ,{
         "caption": "Git: Commit",

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -15,6 +15,7 @@
                             ,{ "caption": "Graph", "command": "git_graph" }
                             ,{ "caption": "-" }
                             ,{ "caption": "Diff", "command": "git_diff" }
+                            ,{ "caption": "DiffTool", "command": "git_diff_tool" }
                             ,{ "caption": "-" }
                             ,{ "caption": "Add", "command": "git_add" }
                             ,{ "caption": "Add Selected Hunk", "command": "git_add_selected_hunk" }
@@ -39,7 +40,7 @@
                             ,{ "caption": "-" }
                             ,{ "caption": "Diff", "command": "git_diff_all" }
                             ,{ "caption": "Diff Staged", "command": "git_diff_commit" }
-                            ,{ "caption": "Diff Tool", "command": "git_diff_tool" }
+                            ,{ "caption": "Diff Tool", "command": "git_diff_tool_all" }
                             ,{ "caption": "Reset Hard", "command": "git_reset_hard_head" }
                             ,{ "caption": "-" }
                             ,{ "caption": "Add...", "command": "git_add_choice" }

--- a/diff.py
+++ b/diff.py
@@ -5,7 +5,7 @@ from git import GitTextCommand, GitWindowCommand
 class GitDiff (object):
     def run(self, edit=None):
         self.run_command(['git', 'diff', '--no-color', '--', self.get_file_name()],
-            self.diff_done)
+                         self.diff_done)
 
     def diff_done(self, result):
         if not result.strip():
@@ -48,6 +48,15 @@ class GitDiffCommitCommand(GitDiffCommit, GitWindowCommand):
     pass
 
 
-class GitDiffTool(GitWindowCommand):
+class GitDiffTool(object):
+    def run(self, edit=None):
+        self.run_command(['git', 'difftool', '--', self.get_file_name()])
+
+
+class GitDiffToolCommand(GitDiffTool, GitTextCommand):
+    pass
+
+
+class GitDiffToolAll(GitWindowCommand):
     def run(self):
         self.run_command(['git', 'difftool'])


### PR DESCRIPTION
Added a new DiffTool command to allow you to diff a single file, and renamed the current command to DiffTool All.  Updated commands and menu text to DiffTool All and DiffTool Current File
