### PR TITLE
Don't force soft word wrapping (Issue #192).

### DIFF
--- a/Git Commit Message.sublime-settings
+++ b/Git Commit Message.sublime-settings
@@ -1,5 +1,3 @@
 {
-  "rulers": [70],
-  "word_wrap": true,
-  "wrap_width": 69
+  "rulers": [70]
 }


### PR DESCRIPTION
Soft wrapping just makes it hard to format the commit message
properly. It must be wrapped manually or otherwise many tools will
just show commit message on one looong line.
