### PR TITLE
Add 'git gui blame' command.

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -7,6 +7,10 @@
         "command": "git_blame"
     }
     ,{
+        "caption": "Git: Blame (GUI)",
+        "command": "git_gui_blame"
+    }
+    ,{
         "caption": "Git: New Tag",
         "command": "git_new_tag"
     }

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -27,6 +27,7 @@
                             ,{ "caption": "Commit Selected Hunk", "command": "git_commit_selected_hunk" }
                             ,{ "caption": "-" }
                             ,{ "caption": "Blame", "command": "git_blame" }
+                            ,{ "caption": "Blame (GUI)", "command": "git_gui_blame" }
                             ,{ "caption": "-" }
                             ,{ "caption": "Toggle Annotations", "command": "git_toggle_annotations" }
                         ]

--- a/history.py
+++ b/history.py
@@ -37,6 +37,16 @@ class GitBlameCommand(GitTextCommand):
                 syntax=plugin_file("syntax/Git Blame.tmLanguage"))
 
 
+class GitGuiBlameCommand(GitTextCommand):
+    def run(self, edit):
+        command = ['git', 'gui', 'blame'];
+        # get the cursor's line number
+        line, column = self.view.rowcol(self.view.sel()[0].begin())
+        command.append('--line=%s' % line)
+        command.append(self.get_file_name())
+        self.run_command(command)
+
+
 class GitLog(object):
     def run(self, edit=None):
         fn = self.get_file_name()


### PR DESCRIPTION
Much easier to work with than text blame when needing to navigate to parent
revisions and see full commit messages.

Automatically scrolls to the line on which the cursor is positioned.