### PR TITLE
Support short date format for git-blame

### DIFF
--- a/syntax/Git Blame.tmLanguage
+++ b/syntax/Git Blame.tmLanguage
@@ -40,7 +40,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^(\^?[a-f0-9]+)\s+([\w\-\d\.\/]*)\s*\((.*?)\s+(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d [+-]\d{4})\s+(\d+)\)</string>
+			<string>^(\^?[a-f0-9]+)\s+([\w\-\d\.\/]*)\s*\((.*?)\s+(\d{4}-\d\d-\d\d( \d\d:\d\d:\d\d [+-]\d{4})?)\s+(\d+)\)</string>
 			<key>name</key>
 			<string>line.comment.git-blame</string>
 		</dict>


### PR DESCRIPTION
Setting git-blame's date format to 'short' caused the syntax regex to no longer match (`git config blame.date short`). This change marks the time and timezone as optional.

This should support both the 'iso' and 'short' formats. The other formats (relative, default, rfc and local) are left unsupported.

(Yes. Git blame has a date format called "default", that is not the  default format. Go figure)
