### PR TITLE
Added "--all" option to gitk command

### DIFF
--- a/git.py
+++ b/git.py
@@ -324,5 +324,5 @@ class GitGuiCommand(GitTextCommand):
 
 class GitGitkCommand(GitTextCommand):
     def run(self, edit):
-        command = ['gitk']
+        command = ['gitk', '--all']
         self.run_command(command)


### PR DESCRIPTION
I rarely use gitk without the `--all` option, so do most of the developers I know.
For this reason I think it better to have the `--all` option by default.

If you think it should go into another command (gitk all) let me know and I will update this PR
