### PR TITLE
Ignore files in non-existent directories

### DIFF
--- a/git.py
+++ b/git.py
@@ -105,23 +105,28 @@ class CommandThread(threading.Thread):
 
     def run(self):
         try:
-            # Per http://bugs.python.org/issue8557 shell=True is required to
-            # get $PATH on Windows. Yay portable code.
-            shell = os.name == 'nt'
-            if self.working_dir != "":
-                os.chdir(self.working_dir)
 
-            proc = subprocess.Popen(self.command,
-                stdout=self.stdout, stderr=subprocess.STDOUT,
-                stdin=subprocess.PIPE,
-                shell=shell, universal_newlines=True)
-            output = proc.communicate(self.stdin)[0]
-            if not output:
-                output = ''
-            # if sublime's python gets bumped to 2.7 we can just do:
-            # output = subprocess.check_output(self.command)
-            main_thread(self.on_done,
-                _make_text_safeish(output, self.fallback_encoding), **self.kwargs)
+            # Ignore directories that no longer exist
+            if os.path.isdir(self.working_dir):
+
+                # Per http://bugs.python.org/issue8557 shell=True is required to
+                # get $PATH on Windows. Yay portable code.
+                shell = os.name == 'nt'
+                if self.working_dir != "":
+                    os.chdir(self.working_dir)
+
+                proc = subprocess.Popen(self.command,
+                    stdout=self.stdout, stderr=subprocess.STDOUT,
+                    stdin=subprocess.PIPE,
+                    shell=shell, universal_newlines=True)
+                output = proc.communicate(self.stdin)[0]
+                if not output:
+                    output = ''
+                # if sublime's python gets bumped to 2.7 we can just do:
+                # output = subprocess.check_output(self.command)
+                main_thread(self.on_done,
+                    _make_text_safeish(output, self.fallback_encoding), **self.kwargs)
+
         except subprocess.CalledProcessError, e:
             main_thread(self.on_done, e.returncode)
         except OSError, e:


### PR DESCRIPTION
On occasion, when switching between branches, files in directories that no longer exist remain open in ST2.

The Git plugin throws an OSError from [the code below](https://github.com/kemayo/sublime-text-2-git/blob/master/git.py#L106) since `chdir` cannot be performed on a missing directory:

``` python
if self.working_dir != "":
    os.chdir(self.working_dir)
```

The error is caught, but the message displayed is still:

> Git binary could not be found in PATH
> 
> Consider using the git_command setting for the Git plugin
> 
> PATH is: ....

This message is not always relevant, since it hides the actual exception.

> OSError: [Errno 2] No such file or directory: '<non-existent directory>'

It would seem that other users are having this issue as well:
- https://github.com/kemayo/sublime-text-2-git/issues/212
- https://github.com/kemayo/sublime-text-2-git/issues/96
- https://github.com/kemayo/sublime-text-2-git/issues/201
- https://github.com/kemayo/sublime-text-2-git/issues/182
- https://github.com/kemayo/sublime-text-2-git/issues/216
- ...

_It might be better to alert the exception message._
