### PR TITLE
Use full PLUGIN_DIRECTORY path

### DIFF
--- a/git.py
+++ b/git.py
@@ -11,7 +11,7 @@ import time
 # __file__ is useless for my purposes. What I want is "Packages/Git", but
 # allowing for the possibility that someone has renamed the file.
 # Fun discovery: Sublime on windows still requires posix path separators.
-PLUGIN_DIRECTORY = os.getcwd().replace(os.path.normpath(os.path.join(os.getcwd(), '..', '..')) + os.path.sep, '').replace(os.path.sep, '/')
+PLUGIN_DIRECTORY = os.getcwd().replace(os.path.sep, '/')
 
 git_root_cache = {}
 


### PR DESCRIPTION
I symlink my Sublime Packages from a directory outside of the normal
location. Not having the full path was causing issues when changing
to syntaxes included in this plugin. Other people might symlink as
well.
