### PR TITLE
Fix add selected hunk with non-ascii characters 

### DIFF
--- a/add.py
+++ b/add.py
@@ -95,7 +95,7 @@ class GitResetHead(object):
     def run(self, edit=None):
         self.run_command(['git', 'reset', 'HEAD', self.get_file_name()])
 
-    def generic_done(self, result):
+    def generic_done(self, result, **kwargs):
         pass
 
 

--- a/git.py
+++ b/git.py
@@ -166,7 +166,7 @@ class GitCommand(object):
             message = kwargs.get('status_message', False) or ' '.join(command)
             sublime.status_message(message)
 
-    def generic_done(self, result):
+    def generic_done(self, result, **kwargs):
         if self.may_change_files and self.active_view() and self.active_view().file_name():
             if self.active_view().is_dirty():
                 result = "WARNING: Current view is dirty.\n\n"


### PR DESCRIPTION
Add selected hunk fails if the hunk contains non ascii characters.
Adding `encode('utf-8')` fixes the error.

```
Exception in thread Thread-353:
Traceback (most recent call last):
  File ".\threading.py", line 532, in __bootstrap_inner
  File ".\git.py", line 122, in run
  File ".\subprocess.py", line 701, in communicate
  File ".\subprocess.py", line 911, in _communicate
UnicodeEncodeError: 'ascii' codec can't encode characters in position 372-373: ordinal not in range(128)
```

I also noticed the issue #181 and fixed it.
