### PR TITLE
ST3: Fix Windows Command Prompt

### DIFF
--- a/git.py
+++ b/git.py
@@ -152,10 +152,16 @@ class CommandThread(threading.Thread):
             if self.working_dir != "":
                 os.chdir(self.working_dir)
 
+            # Windows needs startupinfo in order to start process in background
+            startupinfo = None
+            if os.name == 'nt':
+                startupinfo = subprocess.STARTUPINFO()
+                startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
             # universal_newlines seems to break `log` in python3
             proc = subprocess.Popen(self.command,
                 stdout=self.stdout, stderr=subprocess.STDOUT,
-                stdin=subprocess.PIPE,
+                stdin=subprocess.PIPE, startupinfo=startupinfo,
                 shell=False, universal_newlines=False)
             output = proc.communicate(self.stdin)[0]
             if not output:


### PR DESCRIPTION
On larger git repositories, the Git commands can take a few seconds to run which causes the Command Prompt to popup and steal focus endlessly as it keeps trying to run the status commands.

This fixes that by applying some Windows specific startup flags so that Windows runs the Git process in the background and does not steal focus from the editor.
