### PR TITLE
Fix annotations (icons, colors, refreshing after commit).

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -128,7 +128,7 @@ class GitCommitCommand(GitWindowCommand):
     def commit_done(self, result, **kwargs):
         os.remove(self.message_file.name)
         self.panel(result)
-
+        sublime.active_window().active_view().run_command('git_annotate', {"reload_file": True})
 
 class GitCommitAmendCommand(GitCommitCommand):
     extra_options = "--amend"


### PR DESCRIPTION
Remove line coloring for annotations. 
Add icons for all annotations. 
Reload annotations on view focus, so annotations can be refreshed after commit.

For icon styling (different colors), in theme you can set:
https://gist.github.com/FylmTM/5161306
