### PR TITLE
Solve error on non-ASCII commit messages (#282)

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -121,7 +121,7 @@ class GitCommitCommand(GitWindowCommand):
         message_file.close()
         self.message_file = message_file
         # and actually commit
-        with open(message_file.name, 'r') as fp:
+        with open(message_file.name, 'r', encoding='utf-8') as fp:
             self.run_command(['git', 'commit', '-F', '-', self.extra_options],
                 self.commit_done, working_dir=self.working_dir, stdin=fp.read())
 


### PR DESCRIPTION
Solve UnicodeDecodeError that occurs when trying to make a commit who's
message contains non-ASCII characters (UnicodeDecodeError: 'ascii' codec
can't decode byte 0xc3 in position X: ordinal not in range (128)").

This error was described in issue #282.

The proposed solution involves indicating the exact encoding
(encoding='utf-8') when reading the file in use for writing the commit
message.