### PR TITLE
fix gitk command for Windows

### DIFF
--- a/git.py
+++ b/git.py
@@ -161,11 +161,15 @@ class CommandThread(threading.Thread):
                 startupinfo = subprocess.STARTUPINFO()
                 startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
+            shell = False
+            if sublime.platform() == 'windows':
+                shell = True
+
             # universal_newlines seems to break `log` in python3
             proc = subprocess.Popen(self.command,
                 stdout=self.stdout, stderr=subprocess.STDOUT,
                 stdin=subprocess.PIPE, startupinfo=startupinfo,
-                shell=False, universal_newlines=False)
+                shell=shell, universal_newlines=False)
             output = proc.communicate(self.stdin)[0]
             if not output:
                 output = ''


### PR DESCRIPTION
The command "Gitk" (`GitGitkCommand`) does not work on Windows (I'm using Windows 7) when all others commands are ok.
This is a pull request to correct this issue. It works for me while not breaking others commands, but I would like to know if other people have this issue and if this patch is also ok for them.

The trick to fix the issue is to set the variable `shell` to `true` on Windows, it is inspired by the SideBarGit plugin for Sublime Text 3 (see https://github.com/SublimeText/SideBarGit/blob/95348b1c0802e4873d5b6fca65706914c52d035d/sidebar/SideBarGit.py#L150-L163).

Note: this commit is based on the python3 branch, so I've only tested it with Sublime Text 3 (build 3059).
