### PR TITLE
Git raw command

### DIFF
--- a/git.py
+++ b/git.py
@@ -385,14 +385,41 @@ class GitRawCommand(GitWindowCommand):
 
     def run(self, **args):
 
-        command = str(args.get('command', ''))
-        if command.strip() == "":
+        self.command = str(args.get('command', ''))
+        show_in = str(args.get('show_in', 'pane_below'))
+
+        if self.command.strip() == "":
             self.panel("No git command provided")
             return
         import shlex
-        command_splitted = shlex.split(command)
+        command_splitted = shlex.split(self.command)
         print(command_splitted)
-        self.run_command(command_splitted)
+
+        if show_in == 'pane_below':
+            self.run_command(command_splitted)
+        elif show_in == 'quick_panel':
+            self.run_command(command_splitted, self.show_in_quick_panel)
+        elif show_in == 'new_tab':
+            self.run_command(command_splitted, self.show_in_new_tab)
+
+    def show_in_quick_panel(self, result):
+        self.results = list(result.rstrip().split('\n'))
+        if len(self.results):
+            self.quick_panel(self.results,
+                self.do_nothing, sublime.MONOSPACE_FONT)
+        else:
+            sublime.status_message("Nothing to show")
+
+    def do_nothing(self, picked):
+        return
+
+    def show_in_new_tab(self, result):
+        msg = self.window.new_file()
+        msg.set_scratch(True)
+        msg.set_name(self.command)
+        self._output_to_view(msg, result)
+        msg.sel().clear()
+        msg.sel().add(sublime.Region(0, 0))
 
 
 class GitGuiCommand(GitTextCommand):


### PR DESCRIPTION
I've added a command to run "raw" git commands. User can define whatever command they like. It's like the `Custom Command` command, but using `Default.sublime-commands` file. It allow for faster access to commands and avoid typing again and again the command problem with "custom command".

Example of a `Default.sublime-commands` file:

```
{
    "caption": "Git: show git log in default viewer",
    "command": "git_raw",
    "args": {"command": "git log --oneline"}
}
```

Also, it's possible to choose where to show the result of the command (the default value is `pane_below`):

```
{
    "caption": "Git: show git log in a pane below",
    "command": "git_raw",
    "args": {"command": "git log --oneline", "show_in": "pane_below"}
},
{
    "caption": "Git: show git log in the quick panel",
    "command": "git_raw",
    "args": {"command": "git log --oneline", "show_in": "quick_panel"}
},
{
    "caption": "Git: show git log in a new tab",
    "command": "git_raw",
    "args": {"command": "git log --oneline", "show_in": "new_tab"}
}
```

Note: this commit is based on the python3 branch, so I've only tested it with Sublime Text 3 (build 3059).
