### PR TITLE
WhatTheCommit.com

### DIFF
--- a/Git.sublime-settings
+++ b/Git.sublime-settings
@@ -20,6 +20,9 @@
 	// Use --verbose flag for commit messages
 	,"verbose_commits": true
 
+	// Fill empty quick commit messages with random commit message taken from WhatTheTommit.com
+	,"fill_empty_commits": true
+
 	// How many commit messages to store in the history. Set to 0 to disable.
 	,"history_size": 5
 

--- a/commit.py
+++ b/commit.py
@@ -1,6 +1,10 @@
 import functools
 import tempfile
 import os
+try:
+  import urllib.request as urllib2
+except:
+  import urllib2
 
 import sublime
 import sublime_plugin
@@ -17,8 +21,15 @@ class GitQuickCommitCommand(GitTextCommand):
 
     def on_input(self, message):
         if message.strip() == "":
-            self.panel("No commit message provided")
-            return
+            s = sublime.load_settings("Git.sublime-settings")
+            if  s.get("fill_empty_commits"):
+                req = urllib2.Request('http://whatthecommit.com/index.txt',
+                headers={'User-Agent': 'Sublime Text 2 - Random Message'})
+                res = urllib2.urlopen(req, timeout=5)
+                message =  res.read().strip()
+            else:
+                self.panel("No commit message provided")
+                return
         self.run_command(['git', 'add', self.get_file_name()],
             functools.partial(self.add_done, message))
 


### PR DESCRIPTION
Added the possibility to fill quick empty messages with text taken from WhatTheCommit.com.
Enabled by default, it will create a commit with a message taken from that site if no commit message is specified in "quick commit" and the setting "fill_empty_commits" is keep to true.
Maybe it could be good to set it to a false default.
