### PR TITLE
Show screenshot of available commands in README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,6 +2,8 @@
 
 Git integration: it's pretty handy. Who knew, right?
 
+![Git Commands accessible in Command Palette](https://github.com/kemayo/sublime-text-git/wiki/images/palette.png)
+
 For more information about what's supported, and how to install this, [check the wiki](https://github.com/kemayo/sublime-text-2-git/wiki).
 
 ## Install


### PR DESCRIPTION
Because otherwise it's virtually impossible to know what this plugin does 
when landing on this repo.
