### PR TITLE
Graph syntax highlighting fix

### DIFF
--- a/syntax/Git Graph.tmLanguage
+++ b/syntax/Git Graph.tmLanguage
@@ -45,7 +45,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^([| *\\]+)([0-9a-f]{4,40}) -( \(.*?\))? (.*) (\(.*) (&lt;.*&gt;) .*</string>
+			<string>^([| *\\]+)([0-9a-f]{4,40}) -( \(.*?\))? (.*) (\(.*) (&lt;.*?&gt;) .*</string>
 			<key>name</key>
 			<string>log-entry.git-graph</string>
 		</dict>


### PR DESCRIPTION
If the commit message contains the ">" character, the syntax highlighting for the username part stops at that one instead:

![bug](https://cloud.githubusercontent.com/assets/4781841/3491422/8f8ebef2-0590-11e4-9af9-1607ff38a40d.png)
