### PR TITLE
Fix key error on 32 bit systems

### DIFF
--- a/git.py
+++ b/git.py
@@ -121,10 +121,9 @@ def find_git():
     if not git_path:
         # /usr/local/bin:/usr/local/git/bin
         if os.name == 'nt':
-            extra_paths = (
-                os.path.join(os.environ["ProgramFiles"], "Git", "bin"),
-                os.path.join(os.environ["ProgramFiles(x86)"], "Git", "bin"),
-            )
+            extra_paths = [os.path.join(os.environ["ProgramFiles"], "Git", "bin"), ]
+            if os.environ.__contains__("ProgramFiles(x86)"):
+                extra_paths.append(os.path.join(os.environ["ProgramFiles(x86)"], "Git", "bin"))
         else:
             extra_paths = (
                 '/usr/local/bin',


### PR DESCRIPTION
Small fix to check if "ProgramFiles(x86)" is an environment variable before adding it to the list of extra paths. Fixes error #290.
