### PR TITLE
Match parenthesis at end of timestamp in graph syntax

### DIFF
--- a/syntax/Git Graph.tmLanguage
+++ b/syntax/Git Graph.tmLanguage
@@ -45,7 +45,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^([| *\\]+)([0-9a-f]{4,40}) -( \(.*?\))? (.*) (\(.*) (&lt;.*?&gt;) .*</string>
+			<string>^([| *\\]+)([0-9a-f]{4,40}) -( \(.*?\))? (.*) (\(.*\)) (&lt;.*?&gt;) .*</string>
 			<key>name</key>
 			<string>log-entry.git-graph</string>
 		</dict>


### PR DESCRIPTION
Following on from #355. The closing parenthesis should be explicitly matched to avoid this happening:
![untitled](https://cloud.githubusercontent.com/assets/4781841/4872221/10855d52-61dc-11e4-8ade-72e1c1500ada.png)
