### PR TITLE
Work around for OSX 10.10 PATH issues

### DIFF
--- a/git.py
+++ b/git.py
@@ -118,7 +118,8 @@ class CommandThread(threading.Thread):
                 proc = subprocess.Popen(self.command,
                     stdout=self.stdout, stderr=subprocess.STDOUT,
                     stdin=subprocess.PIPE,
-                    shell=shell, universal_newlines=True)
+                    shell=shell, universal_newlines=True,
+                    env=os.environ)
                 output = proc.communicate(self.stdin)[0]
                 if not output:
                     output = ''


### PR DESCRIPTION
This adds the `env=os.environ` option to the `subprocess.Popen` call.  It provides a decent work around for the upstream PATH problems in OS X 10.10.  

Work around for https://github.com/kemayo/sublime-text-git/issues/368

See https://github.com/SublimeText/LaTeXTools/issues/401#issuecomment-59649977 for details on how this fix works.
Same issue here: https://github.com/SublimeGit/SublimeGit/issues/150
