### PR TITLE
Adding Merge Abort, Tool and launch mergetool on conflict

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -114,6 +114,14 @@
         "command": "git_merge"
     }
     ,{
+        "caption": "Git: Merge Abort",
+        "command": "git_merge_abort"
+    }
+    ,{
+        "caption": "Git: Merge Tool",
+        "command": "git_merge_tool"
+    }
+    ,{
         "caption": "Git: Delete Branch",
         "command": "git_delete_branch"
     }


### PR DESCRIPTION
Introduces `mergetool_on_conflicts` settings (default to false) so that the Merge Branch command will launch mergetool when a merge generates conflicts.

The Merge Abort and Merge Tool commands are added, and are enabled only in the middle of a merge.