### PR TITLE
Fix: `generic_done` may need to ignore extra arguments

### DIFF
--- a/git.py
+++ b/git.py
@@ -238,7 +238,7 @@ class GitCommand(object):
             message = kwargs.get('status_message', False) or ' '.join(command)
             sublime.status_message(message)
 
-    def generic_done(self, result):
+    def generic_done(self, result, **kw):
         if self.may_change_files and self.active_view() and self.active_view().file_name():
             if self.active_view().is_dirty():
                 result = "WARNING: Current view is dirty.\n\n"


### PR DESCRIPTION
Occasionally the console complains that `generic_done` has been called with the `stdin` argument.
My fix is just to let `generic_done` ignore the extra arguments.
If the problem is that the `stdin` argument was not supposed to reach it, this does not solve it =)