### PR TITLE
Adds reset (unstage) and checkout of the selected hunk

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -182,7 +182,7 @@
         "command": "git_custom"
     }
     ,{
-        "caption": "Git Flow: Feature Start", 
+        "caption": "Git Flow: Feature Start",
         "command": "git_flow_feature_start"
     }
     ,{
@@ -224,6 +224,14 @@
     ,{
         "caption": "Git: Add Selected Hunk",
         "command": "git_add_selected_hunk"
+    }
+    ,{
+        "caption": "Git: Checkout Selected Hunk",
+        "command": "git_checkout_selected_hunk"
+    }
+    ,{
+        "caption": "Git: Reset (unstage) Selected Hunk",
+        "command": "git_reset_selected_hunk"
     }
     ,{
         "caption": "Git: Commit Selected Hunk",

--- a/checkout.py
+++ b/checkout.py
@@ -1,0 +1,53 @@
+import os
+import re
+
+import sublime
+from .git import GitTextCommand, GitWindowCommand, git_root
+from .status import GitStatusCommand
+
+
+class GitCheckoutSelectedHunkCommand(GitTextCommand):
+    def run(self, edit):
+        self.run_command(['git', 'diff', '--no-color', '-U1', self.get_file_name()], self.cull_diff)
+
+    def cull_diff(self, result):
+        selection = []
+        for sel in self.view.sel():
+            selection.append({
+                "start": self.view.rowcol(sel.begin())[0] + 1,
+                "end": self.view.rowcol(sel.end())[0] + 1,
+            })
+
+        hunks = [{"diff":""}]
+        i = 0
+        matcher = re.compile('^@@ -([0-9]*)(?:,([0-9]*))? \+([0-9]*)(?:,([0-9]*))? @@')
+        for line in result.splitlines():
+            if line.startswith('@@'):
+                i += 1
+                match = matcher.match(line)
+                start = int(match.group(3))
+                end = match.group(4)
+                if end:
+                    end = start + int(end)
+                else:
+                    end = start
+                hunks.append({"diff": "", "start": start, "end": end})
+            hunks[i]["diff"] += line + "\n"
+
+        diffs = hunks[0]["diff"]
+        hunks.pop(0)
+        selection_is_hunky = False
+        for hunk in hunks:
+            for sel in selection:
+                if sel["end"] < hunk["start"]:
+                    continue
+                if sel["start"] > hunk["end"]:
+                    continue
+                diffs += hunk["diff"]  # + "\n\nEND OF HUNK\n\n"
+                selection_is_hunky = True
+
+        if selection_is_hunky:
+            self.run_command(['git', 'apply', '-R'], stdin=diffs)
+        else:
+            sublime.status_message("No selected hunk")
+

--- a/reset.py
+++ b/reset.py
@@ -1,0 +1,53 @@
+import os
+import re
+
+import sublime
+from .git import GitTextCommand, GitWindowCommand, git_root
+from .status import GitStatusCommand
+
+
+class GitResetSelectedHunkCommand(GitTextCommand):
+    def run(self, edit):
+        self.run_command(['git', 'diff', '--no-color', '--staged', '-U1', self.get_file_name()], self.cull_diff)
+
+    def cull_diff(self, result):
+        selection = []
+        for sel in self.view.sel():
+            selection.append({
+                "start": self.view.rowcol(sel.begin())[0] + 1,
+                "end": self.view.rowcol(sel.end())[0] + 1,
+            })
+
+        hunks = [{"diff":""}]
+        i = 0
+        matcher = re.compile('^@@ -([0-9]*)(?:,([0-9]*))? \+([0-9]*)(?:,([0-9]*))? @@')
+        for line in result.splitlines():
+            if line.startswith('@@'):
+                i += 1
+                match = matcher.match(line)
+                start = int(match.group(3))
+                end = match.group(4)
+                if end:
+                    end = start + int(end)
+                else:
+                    end = start
+                hunks.append({"diff": "", "start": start, "end": end})
+            hunks[i]["diff"] += line + "\n"
+
+        diffs = hunks[0]["diff"]
+        hunks.pop(0)
+        selection_is_hunky = False
+        for hunk in hunks:
+            for sel in selection:
+                if sel["end"] < hunk["start"]:
+                    continue
+                if sel["start"] > hunk["end"]:
+                    continue
+                diffs += hunk["diff"]  # + "\n\nEND OF HUNK\n\n"
+                selection_is_hunky = True
+
+        if selection_is_hunky:
+            self.run_command(['git', 'apply', '-R', '--cached'], stdin=diffs)
+        else:
+            sublime.status_message("No selected hunk")
+


### PR DESCRIPTION
Just a copy paste of the add hunk command with the `-R` flag for the checkout hunk command.

The unstage/reset command also adds the `--cached` parameter.

Should probably be cleaned up to reuse code to get the diff. And share it with the add command. But hey, this works fine.

I'm not really a python developer and someone can probably easily refactor this. But works as is at least.
