### PR TITLE
Merge `Sublime Text git Commit Message Syntax` package

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,3 +20,9 @@ Package Control will automatically keep Git up to date with the latest version.
 ### The rest
 
 If you don't want to use Package Control, [check the wiki](https://github.com/kemayo/sublime-text-git/wiki) for other installation methods on various platforms.
+
+## Acknowledgements
+
+This package contains:
+
+* [Sublime Text git Commit Message Syntax](https://github.com/adambullmer/sublime_git_commit_syntax) by [Adam Bullmer](https://github.com/adambullmer).

--- a/syntax/Git Commit Message.JSON-tmLanguage
+++ b/syntax/Git Commit Message.JSON-tmLanguage
@@ -1,19 +1,121 @@
-{ "name": "Git Commit Message",
-  "scopeName": "text.git-commit", 
-  "fileTypes": ["COMMIT_EDITMSG"], 
+{
+  "name": "Git Commit Message",
+  "scopeName": "text.git-commit",
+  "fileTypes": [
+    "COMMIT_EDITMSG"
+  ],
   "patterns": [
-    { "name": "comment.line.number-sign.git-commit",
-      "match": "^\\s*(#).*$\n?",
-      "captures": {
-        "1": { "name": "punctuation.definition.comment.git-commit" }
-      }
+    {
+      "name": "comment.line.number-sign.git-commit-message",
+      "begin": "^#",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.comment.git-commit-message"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "name": "comment.line.on-branch.git-commit-message",
+          "match": "(?:On branch )([^ ]+)",
+          "captures": {
+            "1": {
+              "name": "support.function.branch.git-commit-message"
+            }
+          }
+        },
+        {
+          "name": "comment.line.on-branch.git-commit-message",
+          "match": "Your branch .* '([^ ']+)'",
+          "captures": {
+            "1": {
+              "name": "support.function.branch.git-commit-message"
+            }
+          }
+        },
+        {
+          "name": "comment.line.untracked.git-commit-message",
+          "begin": " Untracked files:",
+          "beginCaptures": {
+            "0": {
+              "name": "entity.definition.untracked.git-commit-message"
+            }
+          },
+          "end": "^#$",
+          "patterns": [
+            {
+              "name": "comment.line.untracked-file.git-commit-message",
+              "match": "\t(.*)$",
+              "captures": {
+                "1": {
+                  "name": "support.function.file-status.git-commit-message"
+                },
+                "2": {
+                  "name": "constant.character.branch.git-commit-message"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "comment.line.discarded.git-commit-message",
+          "begin": " Change(?:s not staged for commit|d but not updated):",
+          "beginCaptures": {
+            "0": {
+              "name": "entity.definition.discarded.git-commit-message"
+            }
+          },
+          "end": "^#$",
+          "patterns": [
+            {
+              "name": "comment.line.discarded.git-commit-message",
+              "match": "\t([^:]+):(.*)$",
+              "captures": {
+                "1": {
+                  "name": "support.function.file-status.git-commit-message"
+                },
+                "2": {
+                  "name": "constant.character.branch.git-commit-message"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "comment.line.selected.git-commit-message",
+          "begin": " Changes to be committed:",
+          "beginCaptures": {
+            "0": {
+              "name": "entity.definition.selected.git-commit-message"
+            }
+          },
+          "end": "^#$",
+          "patterns": [
+            {
+              "name": "comment.line.selected.git-commit-message",
+              "match": "\t([^:]+):(.*)$",
+              "captures": {
+                "1": {
+                  "name": "support.function.file-status.git-commit-message"
+                },
+                "2": {
+                  "name": "constant.character.branch.git-commit-message"
+                }
+              }
+            }
+          ]
+        }
+      ]
     },
-    { "name": "meta.diff.git-commit",
+    {
+      "name": "meta.diff.git-commit",
       "comment": "diff at the end of the commit message when using commit -v, or viewing a log. End pattern is just something to be never matched so that the meta continues untill the end of the file.",
       "begin": "diff\\ \\-\\-git",
       "end": "(?=xxxxxx)123457",
       "patterns": [
-        { "include": "source.diff" }
+        {
+          "include": "source.diff"
+        }
       ]
     }
   ],

--- a/syntax/Git Commit Message.tmLanguage
+++ b/syntax/Git Commit Message.tmLanguage
@@ -11,19 +11,165 @@
 	<key>patterns</key>
 	<array>
 		<dict>
-			<key>captures</key>
+			<key>begin</key>
+			<string>^#</string>
+			<key>beginCaptures</key>
 			<dict>
-				<key>1</key>
+				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.comment.git-commit</string>
+					<string>punctuation.definition.comment.git-commit-message</string>
 				</dict>
 			</dict>
-			<key>match</key>
-			<string>^\s*(#).*$
-?</string>
+			<key>end</key>
+			<string>$</string>
 			<key>name</key>
-			<string>comment.line.number-sign.git-commit</string>
+			<string>comment.line.number-sign.git-commit-message</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>support.function.branch.git-commit-message</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?:On branch )([^ ]+)</string>
+					<key>name</key>
+					<string>comment.line.on-branch.git-commit-message</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>support.function.branch.git-commit-message</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>Your branch .* '([^ ']+)'</string>
+					<key>name</key>
+					<string>comment.line.on-branch.git-commit-message</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string> Untracked files:</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>entity.definition.untracked.git-commit-message</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>^#$</string>
+					<key>name</key>
+					<string>comment.line.untracked.git-commit-message</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>support.function.file-status.git-commit-message</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>constant.character.branch.git-commit-message</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>	(.*)$</string>
+							<key>name</key>
+							<string>comment.line.untracked-file.git-commit-message</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string> Change(?:s not staged for commit|d but not updated):</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>entity.definition.discarded.git-commit-message</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>^#$</string>
+					<key>name</key>
+					<string>comment.line.discarded.git-commit-message</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>support.function.file-status.git-commit-message</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>constant.character.branch.git-commit-message</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>	([^:]+):(.*)$</string>
+							<key>name</key>
+							<string>comment.line.discarded.git-commit-message</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string> Changes to be committed:</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>entity.definition.selected.git-commit-message</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>^#$</string>
+					<key>name</key>
+					<string>comment.line.selected.git-commit-message</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>support.function.file-status.git-commit-message</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>constant.character.branch.git-commit-message</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>	([^:]+):(.*)$</string>
+							<key>name</key>
+							<string>comment.line.selected.git-commit-message</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 		</dict>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
1. Updated according to code review comments

  * Add "Acknowledgements" section to README.markdown
  * Force pushed & rebased the branch

2. Add the following content to [Commit section in wiki](https://github.com/kemayo/sublime-text-git/wiki#commit) after merge

```text
Syntax highlighting for commit messages:

![Git Commit Message with Syntax support](https://cloud.githubusercontent.com/assets/922234/7244869/8fb0d48a-e814-11e4-9019-b18b4ab008e6.png)
```