### PR TITLE
Some environments won't permit ssh connections to outside addresses.

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -166,6 +166,14 @@
         "command": "git_raw", "args": { "command": "git push", "may_change_files": false }
     }
     ,{
+        "caption": "Git: Push to Custom URL (Refspec=master)",
+        "command": "git_raw", "args": { "command": "git push https://{credentials}@{url} {refspec}", "may_change_files": false, "input_credentials": true, "input_url": true, "input_refspec": false, "default_refspec": "master" }
+    }
+    ,{
+        "caption": "Git: Push to Custom URL, Custom Refspec",
+        "command": "git_raw", "args": { "command": "git push https://{credentials}@{url} {refspec}", "may_change_files": false, "input_credentials": true, "input_url": true, "input_refspec": true, "default_refspec": "master" }
+    }
+    ,{
         "caption": "Git: Push Current Branch",
         "command": "git_push_current_branch"
     }


### PR DESCRIPTION
Likewise, it's often a bad idea to store any password in a plaintext file.
So in order to use git, I need to be prompted for credentials every time.

sublime-commands added:
  "Git: Push to Custom URL (Refspec=master)"
  and
  "Git: Push to Custom URL, Custom Refspec"

  Prompt user for url
    (e.g. 'github.com/wrgeorge1983/sublime-text-git.git')
  and creds
    (e.g. 'username:password')
  and (optionally) refspec
    (e.g. 'python3')
