### PR TITLE
Fix adding folders from panel

### DIFF
--- a/add.py
+++ b/add.py
@@ -27,7 +27,8 @@ class GitAddChoiceCommand(GitStatusCommand):
         else:
             command = ['git']
             picked_file = picked_file.strip('"')
-            if os.path.isfile(working_dir + "/" + picked_file):
+            realpath = working_dir + "/" + picked_file
+            if os.path.isfile(realpath) or os.path.isdir(realpath):
                 command += ['add']
             else:
                 command += ['rm']


### PR DESCRIPTION
When selecting a folder in the "Add..." panel, `git rm` was attempted instead of `git add` because the choice was made by using `os.path.isfile` which returns false on directories.
Solves #410 