### PR TITLE
Use threading lock object instead of commands_working counter

### DIFF
--- a/statusbar.py
+++ b/statusbar.py
@@ -2,7 +2,7 @@ import re
 
 import sublime
 import sublime_plugin
-from .git import GitTextCommand, do_when, are_commands_working
+from .git import GitTextCommand
 
 
 class GitBranchStatusListener(sublime_plugin.EventListener):
@@ -21,10 +21,7 @@ class GitBranchStatusCommand(GitTextCommand):
         else:
             self.view.set_status("git-branch", "")
         if (s.get("statusbar_status")):
-            do_when(
-                lambda: not are_commands_working(),
-                self.run_command,
-                ['git', 'status', '--porcelain'], self.status_done, show_status=False, no_save=True)
+            self.run_command(['git', 'status', '--porcelain'], self.status_done, show_status=False, no_save=True)
         else:
             self.view.set_status("git-status", "")
 


### PR DESCRIPTION
Fixes issue in #426 

Instead of checking for the existence of the git index.lock file we can use a lock object from the threading module in the CommandThread class. It is unlikely that a git command is being run in parallel outside of the user using the sublime plugin so this should be ok. 

are_commands_working was only used in one place and I'm guessing that the incrementing and decrementing of the counter in CommandThread is not thread safe.