### PR TITLE
 Always update status bar

### DIFF
--- a/git.py
+++ b/git.py
@@ -436,6 +436,9 @@ class GitRawCommand(GitWindowCommand):
         elif show_in == 'suppress':
             self.run_command(command_split, self.do_nothing)
 
+        view = self.active_view()
+        view.run_command('git_branch_status')
+
     def show_in_quick_panel(self, result):
         self.results = list(result.rstrip().split('\n'))
         if len(self.results):


### PR DESCRIPTION
Originally when adding files the 'index:' and 'working:' values in the status
bar would be updated reflecting the current branch status. However when using
reset the changes to the branch would not be immediately reflected in the
status bar. The branch status would then be updated in the status bar after
saving the file. This change makes it so that after any git command is run the
branch status is updated in the status bar.