### PR TITLE
Ignore comments and empty lines in .gitignore when updating project ignored files

### DIFF
--- a/git.py
+++ b/git.py
@@ -480,7 +480,9 @@ class GitUpdateIgnoreCommand(sublime_plugin.TextCommand):
                         folder["file_exclude_patterns"] = []
                     for pattern in gitignore_file:
                         pattern = pattern.strip()
-                        if os.path.isdir(os.path.join(path, pattern)):
+                        if len(pattern) == 0 or pattern[0] == '#':
+                            continue
+                        elif os.path.isdir(os.path.join(path, pattern)):
                             if not pattern in folder["folder_exclude_patterns"]:
                                 folder["folder_exclude_patterns"].append(pattern)
                         else:


### PR DESCRIPTION
Currently, the Update Project Ignored Files command adds every line from .gitignore to the project's ignored files, even if the line is blank (and thus should match no files according to the [gitignore documentation](http://git-scm.com/docs/gitignore)) or a comment.

Particularly problematic are the blank lines, as adding a blank pattern to "file_exclude_patterns" matches all files, and thus ignores all files in the project.

This change simply passes over patterns that are blank or contain a # as their first character.