### PR TITLE
Fix a bug in GitCommitSelectedHunk.

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -167,6 +167,6 @@ class GitCommitHistoryCommand(sublime_plugin.TextCommand):
 
 
 class GitCommitSelectedHunk(GitAddSelectedHunkCommand):
-    def run(self, edit):
-        self.run_command(['git', 'diff', '--no-color', self.get_file_name()], self.cull_diff)
+    def cull_diff(self, result):
+        super(GitCommitSelectedHunk, self).cull_diff(result)
         self.get_window().run_command('git_commit')


### PR DESCRIPTION
`GitCommitSelectedHunk` did add & commit asynchronously, so was likely to fail. (On my computer it ALWAYS commit before adding)

I have only tested the code in Sublime 3, so I just did a fix in `python3` branch.