### PR TITLE
Focus proper line on opening scratch view

### DIFF
--- a/git/__init__.py
+++ b/git/__init__.py
@@ -291,7 +291,7 @@ class GitCommand(object):
         }
         output_file.run_command('git_scratch_output', args)
 
-    def scratch(self, output, title=False, position=None, **kwargs):
+    def scratch(self, output, title=False, focused_line=1, **kwargs):
         scratch_file = self.get_window().new_file()
         if title:
             scratch_file.set_name(title)
@@ -300,8 +300,7 @@ class GitCommand(object):
         scratch_file.set_read_only(True)
         self.record_git_root_to_view(scratch_file)
         scratch_file.settings().set('word_wrap', False)
-        if position:
-            sublime.set_timeout(lambda: scratch_file.set_viewport_position(position), 0)
+        scratch_file.run_command('goto_line', {'line': focused_line})
         return scratch_file
 
     def panel(self, output, **kwargs):

--- a/git/history.py
+++ b/git/history.py
@@ -22,10 +22,15 @@ class GitBlameCommand(GitTextCommand):
             callback = self.blame_done
         else:
             callback = functools.partial(self.blame_done,
-                    position=self.view.viewport_position())
+                                         focused_line=self.get_current_line())
 
         command.append(self.get_file_name())
         self.run_command(command, callback)
+
+    def get_current_line(self):
+        (current_line, column) = self.view.rowcol(self.view.sel()[0].a)
+        # line is 1 based
+        return current_line + 1
 
     def get_lines(self):
         selection = self.view.sel()[0]  # todo: multi-select support?
@@ -40,8 +45,8 @@ class GitBlameCommand(GitTextCommand):
         # add one to each, to line up sublime's index with git's
         return begin_line + 1, end_line + 1
 
-    def blame_done(self, result, position=None):
-        view = self.scratch(result, title="Git Blame", position=position,
+    def blame_done(self, result, focused_line=1):
+        view = self.scratch(result, title="Git Blame", focused_line=focused_line,
                             syntax=plugin_file("syntax/Git Blame.tmLanguage"))
 
 
@@ -210,7 +215,7 @@ class GitDocumentCommand(GitBlameCommand):
         # add one to each, to line up sublime's index with git's
         return begin_line + 1, end_line + 1
 
-    def blame_done(self, result, position=None):
+    def blame_done(self, result, focused_line=1):
         shas = set((sha for sha in re.findall(r'^[0-9a-f]+', result, re.MULTILINE) if not re.match(r'^0+$', sha)))
         command = ['git', 'show', '-s', '-z', '--no-color', '--date=iso']
         command.extend(shas)


### PR DESCRIPTION
Using set_viewport_position was flawed as it scrolled the file
visually but kept cursor at the end of the file. With long output,
both would be not in sync, so touching arrow keys would scroll the
view to a completely different place.

Use goto_line instead which handles that properly. If focused_line is
not set, scratch view is scrolled to the top with cursor set on first
line.