### PR TITLE
Adds support for diff --word-diff (--color-words)

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -59,6 +59,21 @@
         "command": "git_diff_commit"
     }
     ,{
+        "caption": "Git: Diff Current File (Words)",
+        "command": "git_diff",
+        "args": { "word_diff": true }
+    }
+    ,{
+        "caption": "Git: Diff All Files (Words)",
+        "command": "git_diff_all",
+        "args": { "word_diff": true }
+    }
+    ,{
+        "caption": "Git: Diff Staged Files (Words)",
+        "command": "git_diff_commit",
+        "args": { "word_diff": true }
+    }
+    ,{
         "caption": "Git: Diff Current File (Ignore Whitespace)",
         "command": "git_diff",
         "args": { "ignore_whitespace": true }

--- a/Git.sublime-settings
+++ b/Git.sublime-settings
@@ -40,7 +40,7 @@
 	,"statusbar_status_symbols" : {"modified": "≠", "added": "+", "deleted": "×", "untracked": "?", "conflicts": "‼", "renamed":"R", "copied":"C", "clean": "✓", "separator": " "}
 
 	// e.g. "Packages/Git/syntax/Git Commit Message.tmLanguage"
-	,"diff_syntax": "Packages/Diff/Diff.tmLanguage"
+	,"diff_syntax": "Packages/Git/syntax/Git Diff.sublime-syntax"
 
 	// Rulers for commit view
 	,"commit_rulers": [70]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -44,6 +44,7 @@
                             ,{ "caption": "Diff (word diff)", "command": "git_diff_all", "args": { "word_diff": true } }
                             ,{ "caption": "Diff (no whitespace)", "command": "git_diff_all", "args": { "ignore_whitespace": true } }
                             ,{ "caption": "Diff Staged", "command": "git_diff_commit" }
+                            ,{ "caption": "Diff Staged (word diff)", "command": "git_diff_commit", "args": { "word_diff": true } }
                             ,{ "caption": "Diff Staged (no whitespace)", "command": "git_diff_commit", "args": { "ignore_whitespace": true } }
                             ,{ "caption": "Diff Tool", "command": "git_raw", "args": { "command": "git difftool", "may_change_files": false } }
                             ,{ "caption": "Reset Hard", "command": "git_reset_hard_head" }

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -15,6 +15,7 @@
                             ,{ "caption": "Graph", "command": "git_graph" }
                             ,{ "caption": "-" }
                             ,{ "caption": "Diff", "command": "git_diff" }
+                            ,{ "caption": "Diff (word diff)", "command": "git_diff", "args": { "word_diff": true } }
                             ,{ "caption": "Diff (no whitespace)", "command": "git_diff", "args": { "ignore_whitespace": true } }
                             ,{ "caption": "DiffTool", "command": "git_raw", "args": { "command": "git difftool", "append_current_file": true, "may_change_files": false } }
                             ,{ "caption": "-" }
@@ -40,6 +41,7 @@
                             ,{ "caption": "Graph", "command": "git_graph_all" }
                             ,{ "caption": "-" }
                             ,{ "caption": "Diff", "command": "git_diff_all" }
+                            ,{ "caption": "Diff (word diff)", "command": "git_diff_all", "args": { "word_diff": true } }
                             ,{ "caption": "Diff (no whitespace)", "command": "git_diff_all", "args": { "ignore_whitespace": true } }
                             ,{ "caption": "Diff Staged", "command": "git_diff_commit" }
                             ,{ "caption": "Diff Staged (no whitespace)", "command": "git_diff_commit", "args": { "ignore_whitespace": true } }

--- a/git/diff.py
+++ b/git/diff.py
@@ -8,10 +8,12 @@ from . import git_root, GitTextCommand, GitWindowCommand, do_when, goto_xy
 
 
 class GitDiff (object):
-    def run(self, edit=None, ignore_whitespace=False):
+    def run(self, edit=None, ignore_whitespace=False, word_diff=False):
         command = ['git', 'diff', '--no-color']
         if ignore_whitespace:
             command.extend(('--ignore-all-space', '--ignore-blank-lines'))
+        if word_diff:
+            command.append('--word-diff')
         command.extend(('--', self.get_file_name()))
         self.run_command(command, self.diff_done)
 
@@ -28,10 +30,12 @@ class GitDiff (object):
 
 
 class GitDiffCommit (object):
-    def run(self, edit=None, ignore_whitespace=False):
+    def run(self, edit=None, ignore_whitespace=False, word_diff=False):
         command = ['git', 'diff', '--cached', '--no-color']
         if ignore_whitespace:
             command.extend(('--ignore-all-space', '--ignore-blank-lines'))
+        if word_diff:
+            command.append('--word-diff')
         self.run_command(command, self.diff_done)
 
     def diff_done(self, result):

--- a/git/diff.py
+++ b/git/diff.py
@@ -4,7 +4,7 @@ import sublime
 import sublime_plugin
 import os
 import re
-from . import git_root, GitTextCommand, GitWindowCommand, do_when, goto_xy
+from . import git_root, GitTextCommand, GitWindowCommand, do_when, goto_xy, plugin_file
 
 
 class GitDiff (object):
@@ -22,7 +22,7 @@ class GitDiff (object):
             self.panel("No output")
             return
         s = sublime.load_settings("Git.sublime-settings")
-        syntax = s.get("diff_syntax", "Packages/Diff/Diff.tmLanguage")
+        syntax = plugin_file("syntax/Git Diff.sublime-syntax")
         if s.get('diff_panel'):
             view = self.panel(result, syntax=syntax)
         else:
@@ -43,7 +43,7 @@ class GitDiffCommit (object):
             self.panel("No output")
             return
         s = sublime.load_settings("Git.sublime-settings")
-        syntax = s.get("diff_syntax", "Packages/Diff/Diff.tmLanguage")
+        syntax = plugin_file("syntax/Git Diff.sublime-syntax")
         self.scratch(result, title="Git Diff", syntax=syntax)
 
 
@@ -137,3 +137,4 @@ class GitGotoDiff(sublime_plugin.TextCommand):
         new_view = v.window().open_file(full_path_file_name)
         do_when(lambda: not new_view.is_loading(),
                 lambda: goto_xy(new_view, self.goto_line, self.column))
+

--- a/git/diff.py
+++ b/git/diff.py
@@ -4,7 +4,7 @@ import sublime
 import sublime_plugin
 import os
 import re
-from . import git_root, GitTextCommand, GitWindowCommand, do_when, goto_xy, plugin_file
+from . import git_root, GitTextCommand, GitWindowCommand, do_when, goto_xy
 
 
 class GitDiff (object):
@@ -22,7 +22,7 @@ class GitDiff (object):
             self.panel("No output")
             return
         s = sublime.load_settings("Git.sublime-settings")
-        syntax = plugin_file("syntax/Git Diff.sublime-syntax")
+        syntax = s.get("diff_syntax", "Packages/Git/syntax/Git Diff.sublime-syntax")
         if s.get('diff_panel'):
             view = self.panel(result, syntax=syntax)
         else:
@@ -43,7 +43,7 @@ class GitDiffCommit (object):
             self.panel("No output")
             return
         s = sublime.load_settings("Git.sublime-settings")
-        syntax = plugin_file("syntax/Git Diff.sublime-syntax")
+        syntax = s.get("diff_syntax", "Packages/Git/syntax/Git Diff.sublime-syntax")
         self.scratch(result, title="Git Diff", syntax=syntax)
 
 

--- a/syntax/Git Diff.sublime-syntax
+++ b/syntax/Git Diff.sublime-syntax
@@ -1,0 +1,71 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: Git Diff
+file_extensions:
+  - diff
+  - patch
+first_line_match: |-
+  (?x)^
+      (===\ modified\ file
+      |==== \s* // .+ \s - \s .+ \s+ ====
+      |Index:[ ]
+      |---\ [^%]
+      |\*\*\*.*\d{4}\s*$
+      |\d+(,\d+)* (a|d|c) \d+(,\d+)* $
+      |diff\ --git[ ]
+      )
+
+scope: source.diff
+contexts:
+  main:
+    - match: '^((\*{15})|(={67})|(-{3}))$\n?'
+      scope: meta.separator.diff
+      captures:
+        1: punctuation.definition.separator.diff
+    - match: ^\d+(,\d+)*(a|d|c)\d+(,\d+)*$\n?
+      scope: meta.diff.range.normal
+    - match: ^(@@)\s*(.+?)\s*(@@)($\n?)?
+      scope: meta.diff.range.unified
+      captures:
+        1: punctuation.definition.range.diff
+        2: meta.toc-list.line-number.diff
+        3: punctuation.definition.range.diff
+    - match: '^(((\-{3}) .+ (\-{4}))|((\*{3}) .+ (\*{4})))$\n?'
+      scope: meta.diff.range.context
+      captures:
+        3: punctuation.definition.range.diff
+        4: punctuation.definition.range.diff
+        6: punctuation.definition.range.diff
+        7: punctuation.definition.range.diff
+    - match: '(^(((-{3}) .+)|((\*{3}) .+))$\n?|^(={4}) .+(?= - ))'
+      scope: meta.diff.header.from-file
+      captures:
+        4: punctuation.definition.from-file.diff
+        6: punctuation.definition.from-file.diff
+        7: punctuation.definition.from-file.diff
+    - match: '(^(\+{3}) .+$\n?| (-) .* (={4})$\n?)'
+      scope: meta.diff.header.to-file
+      captures:
+        2: punctuation.definition.to-file.diff
+        3: punctuation.definition.to-file.diff
+        4: punctuation.definition.to-file.diff
+    - match: ^(((>)( .*)?)|((\+).*))$\n?
+      scope: markup.inserted.diff
+      captures:
+        3: punctuation.definition.inserted.diff
+        6: punctuation.definition.inserted.diff
+    - match: ^(((<)( .*)?)|((-).*))$\n?
+      scope: markup.deleted.diff
+      captures:
+        3: punctuation.definition.inserted.diff
+        6: punctuation.definition.inserted.diff
+    - match: ^Index(:) (.+)$\n?
+      scope: meta.diff.index
+      captures:
+        1: punctuation.separator.key-value.diff
+        2: meta.toc-list.file-name.diff
+    - match: \{\+.+?\+\}
+      scope: markup.inserted.diff
+    - match: \[\-.+?\-\]
+      scope: markup.deleted.diff


### PR DESCRIPTION
Adds support for `diff --word-diff` (same as `--color-words`). Addresses https://github.com/kemayo/sublime-text-git/issues/146.

Adds a `word_diff=False` option to `GitDiff` and `GitDiffCommit` (similarly to `ignore_whitespace=False`).

Syntax highlighting is accomplished via a new file `Git Diff.tmLanguage` which adds rules for the `{+added+}` and `[-removed-]` patterns produced by `diff --word-diff`. Also removes the rule for lines starting with an exclamation mark, which is useless for `git diff` and interferes with word-diff syntax highlighting on exclamation mark commented lines. (see https://github.com/divmain/GitSavvy/issues/295 for reference)
