### PR TITLE
'git mv', 'git rm' command implementation

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -82,14 +82,6 @@
         "command": "git_raw", "args": { "command": "git difftool", "may_change_files": false }
     }
     ,{
-        "caption": "Git: Diff Tool Current File Staged",
-        "command": "git_diff_tool_commit"
-    }
-    ,{
-        "caption": "Git: Diff Tool Staged",
-        "command": "git_diff_tool_commit_all"
-    }
-    ,{
         "caption": "Git: Commit",
         "command": "git_commit"
     }
@@ -118,10 +110,6 @@
         "command": "git_branch"
     }
     ,{
-        "caption": "Git: Track Remote Branch",
-        "command": "git_track_remote_branch"
-    }
-    ,{
         "caption": "Git: Merge Branch",
         "command": "git_merge"
     }
@@ -144,10 +132,6 @@
     ,{
         "caption": "Git: Stash Drop",
         "command": "git_stash_drop"
-    }
-    ,{
-        "caption": "Git: Stash List",
-        "command": "git_stash_list"
     }
     ,{
         "caption": "Git: Add Current File",
@@ -178,10 +162,6 @@
         "command": "git_raw", "args": { "command": "git pull --rebase" }
     }
     ,{
-        "caption": "Git: Pull Using Rebase",
-        "command": "git_pull_rebase"
-    }
-    ,{
         "caption": "Git: Pull Current Branch",
         "command": "git_pull_current_branch"
     }
@@ -206,7 +186,7 @@
         "command": "git_custom"
     }
     ,{
-        "caption": "Git Flow: Feature Start",
+        "caption": "Git Flow: Feature Start", 
         "command": "git_flow_feature_start"
     }
     ,{
@@ -258,16 +238,8 @@
         "command": "git_gui"
     }
     ,{
-        "caption": "Git: Gitk This File",
-        "command": "git_gitk_this_file"
-    }
-    ,{
         "caption": "Git: Gitk",
         "command": "git_gitk"
-    }
-    ,{
-        "caption": "Git: Gitk All",
-        "command": "git_gitk_all"
     }
     ,{
         "caption": "Git: Commit history",
@@ -276,5 +248,17 @@
     ,{
         "caption": "Git: Update Project Ignored Files",
         "command": "git_update_ignore"
+    }
+    ,{
+        "caption": "Git: Move Current File",
+        "command": "git_mv"
+    }
+    ,{
+        "caption": "Git: Rename/Move Current File",
+        "command": "git_mv", "args": { "rename": true }
+    }
+    ,{
+        "caption": "Git: Remove/Delete Current File",
+        "command": "git_raw", "args": { "command": "git rm", "append_current_file": true }
     }
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -82,6 +82,14 @@
         "command": "git_raw", "args": { "command": "git difftool", "may_change_files": false }
     }
     ,{
+        "caption": "Git: Diff Tool Current File Staged",
+        "command": "git_diff_tool_commit"
+    }
+    ,{
+        "caption": "Git: Diff Tool Staged",
+        "command": "git_diff_tool_commit_all"
+    }
+    ,{
         "caption": "Git: Commit",
         "command": "git_commit"
     }
@@ -110,6 +118,10 @@
         "command": "git_branch"
     }
     ,{
+        "caption": "Git: Track Remote Branch",
+        "command": "git_track_remote_branch"
+    }
+    ,{
         "caption": "Git: Merge Branch",
         "command": "git_merge"
     }
@@ -132,6 +144,10 @@
     ,{
         "caption": "Git: Stash Drop",
         "command": "git_stash_drop"
+    }
+    ,{
+        "caption": "Git: Stash List",
+        "command": "git_stash_list"
     }
     ,{
         "caption": "Git: Add Current File",
@@ -162,6 +178,10 @@
         "command": "git_raw", "args": { "command": "git pull --rebase" }
     }
     ,{
+        "caption": "Git: Pull Using Rebase",
+        "command": "git_pull_rebase"
+    }
+    ,{
         "caption": "Git: Pull Current Branch",
         "command": "git_pull_current_branch"
     }
@@ -186,7 +206,7 @@
         "command": "git_custom"
     }
     ,{
-        "caption": "Git Flow: Feature Start", 
+        "caption": "Git Flow: Feature Start",
         "command": "git_flow_feature_start"
     }
     ,{
@@ -238,8 +258,16 @@
         "command": "git_gui"
     }
     ,{
+        "caption": "Git: Gitk This File",
+        "command": "git_gitk_this_file"
+    }
+    ,{
         "caption": "Git: Gitk",
         "command": "git_gitk"
+    }
+    ,{
+        "caption": "Git: Gitk All",
+        "command": "git_gitk_all"
     }
     ,{
         "caption": "Git: Commit history",

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -21,6 +21,9 @@
                             ,{ "caption": "Add", "command": "git_raw", "args": { "command": "git add", "append_current_file": true } }
                             ,{ "caption": "Add Selected Hunk", "command": "git_add_selected_hunk" }
                             ,{ "caption": "-" }
+                            ,{ "caption": "Move/Rename...", "command": "git_mv"}
+                            ,{ "caption": "Remove/Delete", "command": "git_raw", "args": { "command": "git rm", "append_current_file": true } }
+                            ,{ "caption": "-" }
                             ,{ "caption": "Reset", "command": "git_raw", "args": { "command": "git reset HEAD", "append_current_file": true, "show_in": "suppress" } }
                             ,{ "caption": "Checkout (Discard Changes)", "command": "git_raw", "args": { "command": "git checkout", "append_current_file": true } }
                             ,{ "caption": "-" }
@@ -54,8 +57,6 @@
                             ,{ "caption": "Amend Last Commit", "command": "git_commit_amend" }
                             ,{ "caption": "-" }
                             ,{ "caption": "Open...", "command": "git_open_file" }
-                            ,{ "caption": "Open Config", "command": "git_open_config_file" }
-                            ,{ "caption": "Open Url", "command": "git_open_config_url", "args": { "url_param": "remote.origin.url" } }
                         ]
                     }
                     ,{
@@ -66,7 +67,6 @@
                             ,{ "caption": "Pop", "command": "git_raw", "args": { "command": "git stash pop", "may_change_files": true } }
                             ,{ "caption": "Apply", "command": "git_stash_apply" }
                             ,{ "caption": "Drop", "command": "git_stash_drop" }
-                            ,{ "caption": "List", "command": "git_stash_list" }
                         ]
                     }
                     ,{ "caption": "-" }

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -57,6 +57,8 @@
                             ,{ "caption": "Amend Last Commit", "command": "git_commit_amend" }
                             ,{ "caption": "-" }
                             ,{ "caption": "Open...", "command": "git_open_file" }
+                            ,{ "caption": "Open Config", "command": "git_open_config_file" }
+                            ,{ "caption": "Open Url", "command": "git_open_config_url", "args": { "url_param": "remote.origin.url" } }
                         ]
                     }
                     ,{
@@ -67,6 +69,7 @@
                             ,{ "caption": "Pop", "command": "git_raw", "args": { "command": "git stash pop", "may_change_files": true } }
                             ,{ "caption": "Apply", "command": "git_stash_apply" }
                             ,{ "caption": "Drop", "command": "git_stash_drop" }
+                            ,{ "caption": "List", "command": "git_stash_list" }
                         ]
                     }
                     ,{ "caption": "-" }

--- a/git/mv.py
+++ b/git/mv.py
@@ -1,0 +1,43 @@
+import os
+
+import sublime
+import functools
+from . import GitWindowCommand
+
+class GitMv(GitWindowCommand):
+    def run(self, **args):
+        filename = self._active_file_name()
+        branch, leaf = os.path.split(filename)
+
+        if not os.access(filename, os.W_OK):
+            sublime.error_message(leaf + " is read-only")
+
+        inputtext = "New path/name"
+        placeholder = filename
+        # rename does not change mechanic, only the following with exception of retarget path
+        rename = args.get('rename', False)
+        if rename:
+            inputtext = "Rename to"
+            placeholder = leaf
+
+        panel = self.get_window().show_input_panel(inputtext, placeholder,
+            functools.partial(self.on_input, rename, branch), None, None)
+
+        name, ext = os.path.splitext(leaf)
+        panel.sel().clear()
+        panel.sel().add(sublime.Region(0, len(name)))
+
+    def on_input(self, rename, branch, newpath):
+        newpath = str(newpath)  # avoiding unicode
+        if newpath.strip() == "":
+            self.panel("No input received")
+            return
+        import shlex
+        command_splitted = ['git', 'mv', self._active_file_name(), newpath]
+        if rename:
+            newpath = os.path.realpath(branch + os.sep + newpath)
+        print(command_splitted)
+        self.run_command(command_splitted, functools.partial(self.on_done, newpath))
+
+    def on_done(self, newpath, gitresponse):
+        self.active_view().retarget(newpath)

--- a/git_commands.py
+++ b/git_commands.py
@@ -36,6 +36,7 @@ mods_load_order = [
     '.stash',
     '.statusbar',
     '.flow',
+    '.mv',
 ]
 
 reload_mods = [mod for mod in sys.modules if mod[0:3] in ('git', 'Git') and sys.modules[mod] is not None]
@@ -61,6 +62,7 @@ try:
     from .git.diff import *  # noqa
     from .git.flow import *  # noqa
     from .git.history import *  # noqa
+    from .git.mv import *  # noqa
     from .git.repo import *  # noqa
     from .git.stash import *  # noqa
     from .git.status import *  # noqa
@@ -75,6 +77,7 @@ except (ImportError, ValueError):
     from git.diff import *  # noqa
     from git.flow import *  # noqa
     from git.history import *  # noqa
+    from git.mv import *  # noqa
     from git.repo import *  # noqa
     from git.stash import *  # noqa
     from git.status import *  # noqa


### PR DESCRIPTION
Way to resolve #366 by also adding new menu commands. Rename and move are pretty much equal, rename uses the filename as the placeholder within the input, while move uses the whole file path. 'git rm' is simply a git_raw added to Main and sublime-commands. Tested only on Windows.
