### PR TITLE
Add support for git-flow tag messages.

### DIFF
--- a/Git.sublime-settings
+++ b/Git.sublime-settings
@@ -29,6 +29,9 @@
 
 	// Show git flow commands
 	,"flow": false
+	
+	// By default git flow release and hotfix will tag a version. Set to true to disable.
+	,"flow-notag": false
 
 	// Annotations default to being on for all files. Can be slow in some cases.
 	,"annotations": false

--- a/git/flow.py
+++ b/git/flow.py
@@ -10,6 +10,12 @@ class GitFlowCommand(GitWindowCommand):
         if s.get('flow'):
             return True
         return False
+    
+    def is_notag(self):
+        s = sublime.load_settings("Git.sublime-settings")
+        if s.get('flow-notag'):
+            return True
+        return False
 
 
 class GitFlowFeatureStartCommand(GitFlowCommand):
@@ -63,7 +69,14 @@ class GitFlowReleaseFinishCommand(GitFlowCommand):
         if picked_release.startswith("*"):
             picked_release = picked_release.strip("*")
         picked_release = picked_release.strip()
-        self.run_command(['git', 'flow', 'release', 'finish', picked_release])
+        if self.is_notag():
+            self.run_command(['git', 'flow', 'release', 'finish', '-n', picked_release])
+        else:
+            self.picked_release = picked_release
+            self.get_window().show_input_panel('Enter Tag message:', '', self.tag_message_done, None, None)
+    
+    def tag_message_done(self, tag_message):
+        self.run_command(['git', 'flow', 'release', 'finish', '-m', tag_message, self.picked_release])
 
 
 class GitFlowHotfixStartCommand(GitFlowCommand):
@@ -90,4 +103,11 @@ class GitFlowHotfixFinishCommand(GitFlowCommand):
         if picked_hotfix.startswith("*"):
             picked_hotfix = picked_hotfix.strip("*")
         picked_hotfix = picked_hotfix.strip()
-        self.run_command(['git', 'flow', 'hotfix', 'finish', picked_hotfix])
+        if self.is_notag():
+            self.run_command(['git', 'flow', 'hotfix', 'finish', '-n', picked_hotfix])
+        else:
+            self.picked_hotfix = picked_hotfix
+            self.get_window().show_input_panel('Enter Tag message:', '', self.tag_message_done, None, None)
+
+    def tag_message_done(self, tag_message):
+        self.run_command(['git', 'flow', 'hotfix', 'finish', '-m', tag_message, self.picked_hotfix])


### PR DESCRIPTION
- Configuration value that allows the `-n` flag for no tags.
- Input panel for entering `-m "entered tag message"` style finish.

Note that not having this in place broke hotfix and release finish commands.
As git flow would try to interactively obtain a tag message from the user and error.