### PR TITLE
Fix goto diff for single line only (base on Git 2.10.0).

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -90,12 +90,12 @@ class GitGotoDiff(sublime_plugin.TextCommand):
 
             pt = v.line(pt - 1).a
 
-        hunk = re.match(r"^@@ -(\d+),(\d+) \+(\d+),(\d+) @@.*", hunk_line)
+        hunk = re.match(r"^@@ -(\d+)(,(\d+))? \+(\d+)(,(\d+))? @@.*", hunk_line)
         if not hunk:
             sublime.status_message("No hunk info")
             return
 
-        hunk_start_line = hunk.group(3)
+        hunk_start_line = hunk.group(4)
         self.goto_line = int(hunk_start_line) + line_offset - 1
 
         git_root_dir = v.settings().get("git_root_dir")


### PR DESCRIPTION
like:
--- a/hello.txt
+++ b/hello.txt
@@ -1 +1 @@
-hello world!
\ No newline at end of file
+ new line
\ No newline at end of file

--- a/hello.txt
+++ b/hello.txt
@@ -1 +1,2 @@
-hello world!
\ No newline at end of file
+ hello world!
+ new line
\ No newline at end of file

--- a/hello.txt
+++ b/hello.txt
@@ -1,2 +1 @@
- hello world!
  new line
\ No newline at end of file