### PR TITLE
support view commits by hash ids on log graph window

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -39,6 +39,14 @@
         "command": "git_log_all"
     }
     ,{
+        "caption": "Git: View Commits by Hash IDs from Current Selections",
+        "command": "git_log_by_hash_id_from_sels"
+    }
+    ,{
+        "caption": "Git: View Commits by Hash IDs from Current Lines",
+        "command": "git_log_by_hash_id_from_lines"
+    }
+    ,{
         "caption": "Git: Graph Current File",
         "command": "git_graph"
     }


### PR DESCRIPTION
refer to issue #492 

- Run <code>Git: Graph All</code> to show history as Graph.
- Highlight Hash ID of commits (or just leave cursor stay on the word of Hash ID)
- Run <code>Git: View Commits by Hash IDs from Current Selections</code> to view commits.

![image](https://cloud.githubusercontent.com/assets/12200119/18899646/0e3d98e6-856d-11e6-959b-bac3a73d3b58.png)
![image](https://cloud.githubusercontent.com/assets/12200119/18899674/4965fdf0-856d-11e6-844b-4cbadadbacc4.png)
![image](https://cloud.githubusercontent.com/assets/12200119/18899714/998e0c14-856d-11e6-9ffd-dc70e304adc6.png)
