### PR TITLE
Fix to work with Windows backslashes in __file__

### DIFF
--- a/git/__init__.py
+++ b/git/__init__.py
@@ -22,7 +22,7 @@ def find_plugin_directory():
         match = re.search(r"([^\\/]+)\.sublime-package", __file__)
         if match:
             return "Packages/" + match.group(1)
-    if __file__.startswith('./'):
+    if __file__.startswith('./') or __file__.startswith('.\\'):
         # ST2, we get "./git/__init__.py" which is pretty useless since we want the part above that
         # However, os.getcwd() is the plugin directory!
         full = os.getcwd()


### PR DESCRIPTION
This fixes issues #506, #484, and #457, which seem to be Windows 10 specific. I checked, and on Windows 10 and Python 3.5, __file__ is .\git\__init__.pyc, so you need to check for backslashes also.