### PR TITLE
Fix import config to edit local config and browse repository

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -309,4 +309,12 @@
         "caption": "Git: No Assume Unchanged",
         "command": "git_update_index_no_assume_unchanged"
     }
+    ,{
+        "caption": "Git: Open Local Config",
+        "command": "git_open_config_file"
+    }
+    ,{
+        "caption": "Git: Open Url",
+        "command": "git_open_config_url", "args": { "url_param": "remote.origin.url" }
+    }
 ]

--- a/git_commands.py
+++ b/git_commands.py
@@ -61,6 +61,7 @@ try:
     from .git.add import *  # noqa
     from .git.index import *  # noqa
     from .git.annotate import *  # noqa
+    from .git.config import *  # noqa
     from .git.commit import *  # noqa
     from .git.diff import *  # noqa
     from .git.flow import *  # noqa
@@ -78,6 +79,7 @@ except (ImportError, ValueError):
     from git.add import *  # noqa
     from git.index import *  # noqa
     from git.annotate import *  # noqa
+    from git.config import *  # noqa
     from git.commit import *  # noqa
     from git.diff import *  # noqa
     from git.flow import *  # noqa


### PR DESCRIPTION
Hi,

The commands related to the `config` package was not imported anymore.
This PR fixes it.

As a reminder, the `config` package contains 2 commands I developed back in the day:
* Open Local Git Config
* Open the URL related to the repository with the default browser

The PR fixes also the 2 menu entries which were disabled:
* `Tools > Git > Whole repo > Open Config`
* `Tools > Git > Whole repo > Open URL`

Thanks
