### PR TITLE
Try harder to get the git root directory the first time GitGotoDiff is called

### DIFF
--- a/git/__init__.py
+++ b/git/__init__.py
@@ -81,6 +81,14 @@ def git_root_exist(directory):
     return git_root(directory)
 
 
+# try to get an open folder from the window
+def get_open_folder_from_window(window):
+    try:  # handle case with no open folder
+        return window.folders()[0]
+    except IndexError:
+        return ''
+
+
 def view_contents(view):
     region = sublime.Region(0, view.size())
     return view.substr(region)
@@ -392,10 +400,7 @@ class GitWindowCommand(GitCommand, sublime_plugin.WindowCommand):
         file_name = self.active_file_path()
         if file_name:
             return os.path.realpath(os.path.dirname(file_name))
-        try:  # handle case with no open folder
-            return self.window.folders()[0]
-        except IndexError:
-            return ''
+        return get_open_folder_from_window(self.window)
 
     def get_window(self):
         return self.window

--- a/git/diff.py
+++ b/git/diff.py
@@ -4,7 +4,7 @@ import sublime
 import sublime_plugin
 import os
 import re
-from . import GitTextCommand, GitWindowCommand, do_when, goto_xy
+from . import GitTextCommand, GitWindowCommand, do_when, goto_xy, git_root, get_open_folder_from_window
 
 
 class GitDiff (object):
@@ -99,6 +99,10 @@ class GitGotoDiff(sublime_plugin.TextCommand):
         self.goto_line = int(hunk_start_line) + line_offset - 1
 
         git_root_dir = v.settings().get("git_root_dir")
+        # See if we can get the git root directory if we haven't saved it yet
+        if not git_root_dir:
+            working_dir = get_open_folder_from_window(v.window())
+            git_root_dir = git_root(working_dir) if working_dir else None
 
         # Sanity check and see if the file we're going to try to open even
         # exists. If it does not, prompt the user for the correct base directory


### PR DESCRIPTION
The problem is that we _always_ prompt the user for the root git directory. GitWindowCommand has a nice little addition to its get_working_dir() method to try to get an open folder from the window as a last ditch effort. This change refactors the code from GitWindowCommand.get_working_dir() out into a reusable method named get_open_folder_from_window(). GitGotoDiff can now use the new get_open_folder_from_window() method to try to get a git root directory if one hasn't been set yet.