### PR TITLE
Don't save anonymous buffers when running commands

### DIFF
--- a/git/__init__.py
+++ b/git/__init__.py
@@ -264,11 +264,13 @@ class GitCommand(object):
             kwargs[str('fallback_encoding')] = str(self.active_view().settings().get('fallback_encoding').rpartition('(')[2].rpartition(')')[0])
 
         s = sublime.load_settings("Git.sublime-settings")
-        if (s.get('save_first')
-            and self.active_view()
-            and self.active_view().file_name()
-            and self.active_view().is_dirty()
-            and not no_save):
+        if (
+            s.get('save_first') and
+            self.active_view() and
+            self.active_view().file_name() and
+            self.active_view().is_dirty() and
+            not no_save
+        ):
             self.active_view().run_command('save')
         if command[0] == 'git':
             us = sublime.load_settings('Preferences.sublime-settings')

--- a/git/__init__.py
+++ b/git/__init__.py
@@ -264,7 +264,11 @@ class GitCommand(object):
             kwargs[str('fallback_encoding')] = str(self.active_view().settings().get('fallback_encoding').rpartition('(')[2].rpartition(')')[0])
 
         s = sublime.load_settings("Git.sublime-settings")
-        if s.get('save_first') and self.active_view() and self.active_view().is_dirty() and not no_save:
+        if (s.get('save_first')
+            and self.active_view()
+            and self.active_view().file_name()
+            and self.active_view().is_dirty()
+            and not no_save):
             self.active_view().run_command('save')
         if command[0] == 'git':
             us = sublime.load_settings('Preferences.sublime-settings')


### PR DESCRIPTION
I often write notes in anonymous buffers, not backed by a file. Currently, with `save_first` enabled, running a git command over such a buffer will attempt to save it, which I don't want. Bugged me for years. This PR fixes it.

(Edit: thanks for the plugin btw! Very useful!)