### PR TITLE
"git wtf" command: get a history of the current selection

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -7,6 +7,10 @@
         "command": "git_blame"
     }
     ,{
+        "caption": "Git: WTF",
+        "command": "git_wtf"
+    }
+    ,{
         "caption": "Git: Document Selection",
         "command": "git_document"
     }

--- a/git/history.py
+++ b/git/history.py
@@ -50,6 +50,27 @@ class GitBlameCommand(GitTextCommand):
             syntax=plugin_file("syntax/Git Blame.tmLanguage")
         )
 
+class GitWtfCommand(GitBlameCommand):
+    def run(self, edit):
+        command = ['git', 'log']
+        line_ranges = [self.get_lines(selection) for selection in self.view.sel() if not selection.empty()]
+
+        if line_ranges:
+            for line_range in line_ranges:
+                command.extend(
+                    ('-L', str(line_range[0]) + ',' + str(line_range[1]) + ':' + self.get_file_name())
+                )
+        else:
+            command.extend(('--follow', '--'))
+            command.append(self.get_file_name())
+
+        self.run_command(command, self.wtf_done)
+
+    def wtf_done(self, result):
+        self.scratch(
+            result, title="Git WTF",
+            syntax=plugin_file("syntax/Git Commit View.tmLanguage")
+        )
 
 class GitLog(object):
     def run(self, edit=None):


### PR DESCRIPTION
![sublime-git-wtf](https://user-images.githubusercontent.com/14014/36938866-ff905498-1f1f-11e8-8aef-ef7d2b9d4d0f.gif)

This came about to scratch my own itch - it provides a counterpart to sublime-text-git's blame handling that summarises the history of a set of lines rather than the surface level information provided by the most recent commits that changed each line.

It's a simple wrapper round `git log -L` - https://git-scm.com/docs/git-log#git-log--Lltstartgtltendgtltfilegt

I'd love to extend this to support following functions rather than line ranges, but this appears more involved - it's based on per language regexen to match the methods with language tailored defaults usually configured via `.gitattributes` (http://urbanautomaton.com/blog/2014/09/22/tracking-method-history-in-git/). It's probably easiest to duplicate those regexen in to plugin itself. It's also not entirely clear to me what would be the ideal UX for choosing method over range.

Hopefully the naming isn't too abrasive... 😃 