### PR TITLE
Add option to show untracked files on the diff output

### DIFF
--- a/Git.sublime-settings
+++ b/Git.sublime-settings
@@ -51,4 +51,8 @@
 	// Watch for gitignore changes?
 	// When found, import them. This will hide the ignored files from the sidebar.
 	,"gitignore_sync": false
+
+	// Allows diff to show untracked (new) files as well, instead of omitting
+	// them until staged
+	,"diff_untracked_files": false
 }


### PR DESCRIPTION
This stages the untracked files using the intent-to-add flag, -N.
Essentially, a 0-byte version of the files is staged, allowing the full file to be show as a difference.
This operation is reversed as soon as the diff output is generated by reseting the files back to their untracked status.

This closes #554 