### PR TITLE
Select the third entry on the 'Add...' quick panel by default

### DIFF
--- a/git/status.py
+++ b/git/status.py
@@ -21,9 +21,16 @@ class GitStatusCommand(GitWindowCommand):
             sublime.status_message("Nothing to show")
 
     def show_status_list(self):
+        # selects the first actual entry on the list of modifications,
+        # instead of the 'all files' one
+        selected_index = 0
+        if len(self.results) > 2:
+            selected_index = 2
+
         self.quick_panel(
             self.results, self.panel_done,
-            sublime.MONOSPACE_FONT
+            sublime.MONOSPACE_FONT,
+            selected_index
         )
 
     def status_filter(self, item):


### PR DESCRIPTION
Since the first two options available on the panel are there for edge cases, and most of the selections will go to individual files, it makes sense to have the default selected index skip those first two.

At least that's how I work. I usually have the diff screen open together with the 'Add...' panel, then I select each file I wish to stage at a time.
The way it is now force me to press down two time after every selection.