### PR TITLE
Add a menu to checkout any version of the file

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -26,6 +26,7 @@
                             ,{ "caption": "-" }
                             ,{ "caption": "Reset", "command": "git_raw", "args": { "command": "git reset HEAD", "append_current_file": true, "show_in": "suppress" } }
                             ,{ "caption": "Checkout (Discard Changes)", "command": "git_raw", "args": { "command": "git checkout", "append_current_file": true } }
+                            ,{ "caption": "Checkout (Any version)", "command": "git_log_checkout" }
                             ,{ "caption": "-" }
                             ,{ "caption": "Quick Commit Current File", "command": "git_quick_commit" }
                             ,{ "caption": "Commit Selected Hunk", "command": "git_commit_selected_hunk" }

--- a/git/history.py
+++ b/git/history.py
@@ -106,6 +106,16 @@ class GitLogAllCommand(GitLog, GitWindowCommand):
     pass
 
 
+class GitLogCheckoutCommand(GitLogCommand):
+    """This command is used to check any version of a file."""
+    def log_result(self, ref):
+        self.run_command(
+            ['git', 'checkout', ref, '--', self.get_file_name()])
+
+    def details_done(self, result):
+        pass
+
+
 class GitShow(object):
     def run(self, edit=None):
         # GitLog Copy-Past


### PR DESCRIPTION
Many times we need to check a historical version of a file, not just the latest version. So, I added this feature to check any committed version.
Please accept my request.
Thanks!
<img width="648" alt="2018-08-09 1 06 07" src="https://user-images.githubusercontent.com/13346448/43853048-80f68f2a-9b71-11e8-8a99-06aa8d71a382.png">

