### PR TITLE
Add support for --word-diff, rebased

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -63,6 +63,21 @@
         "command": "git_diff_commit"
     }
     ,{
+        "caption": "Git: Diff Current File (Words)",
+        "command": "git_diff",
+        "args": { "word_diff": true }
+    }
+    ,{
+        "caption": "Git: Diff All Files (Words)",
+        "command": "git_diff_all",
+        "args": { "word_diff": true }
+    }
+    ,{
+        "caption": "Git: Diff Staged Files (Words)",
+        "command": "git_diff_commit",
+        "args": { "word_diff": true }
+    }
+    ,{
         "caption": "Git: Diff Current File (Ignore Whitespace)",
         "command": "git_diff",
         "args": { "ignore_whitespace": true }

--- a/Git.sublime-settings
+++ b/Git.sublime-settings
@@ -43,7 +43,7 @@
 	,"statusbar_status_symbols" : {"modified": "≠", "added": "+", "deleted": "×", "untracked": "?", "conflicts": "‼", "renamed":"R", "copied":"C", "clean": "✓", "separator": " "}
 
 	// e.g. "Packages/Git/syntax/Git Commit Message.tmLanguage"
-	,"diff_syntax": "Packages/Diff/Diff.tmLanguage"
+	,"diff_syntax": "Packages/Git/syntax/Git Diff.sublime-syntax"
 
 	// Rulers for commit view
 	,"commit_rulers": [70]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -15,6 +15,7 @@
                             ,{ "caption": "Graph", "command": "git_graph" }
                             ,{ "caption": "-" }
                             ,{ "caption": "Diff", "command": "git_diff" }
+                            ,{ "caption": "Diff (word diff)", "command": "git_diff", "args": { "word_diff": true } }
                             ,{ "caption": "Diff (no whitespace)", "command": "git_diff", "args": { "ignore_whitespace": true } }
                             ,{ "caption": "DiffTool", "command": "git_raw", "args": { "command": "git difftool", "append_current_file": true, "may_change_files": false } }
                             ,{ "caption": "-" }
@@ -43,8 +44,10 @@
                             ,{ "caption": "Graph", "command": "git_graph_all" }
                             ,{ "caption": "-" }
                             ,{ "caption": "Diff", "command": "git_diff_all" }
+                            ,{ "caption": "Diff (word diff)", "command": "git_diff_all", "args": { "word_diff": true } }
                             ,{ "caption": "Diff (no whitespace)", "command": "git_diff_all", "args": { "ignore_whitespace": true } }
                             ,{ "caption": "Diff Staged", "command": "git_diff_commit" }
+                            ,{ "caption": "Diff Staged (word diff)", "command": "git_diff_commit", "args": { "word_diff": true } }
                             ,{ "caption": "Diff Staged (no whitespace)", "command": "git_diff_commit", "args": { "ignore_whitespace": true } }
                             ,{ "caption": "Diff Tool", "command": "git_raw", "args": { "command": "git difftool", "may_change_files": false } }
                             ,{ "caption": "Reset Hard", "command": "git_reset_hard_head" }

--- a/git/diff.py
+++ b/git/diff.py
@@ -8,19 +8,21 @@ from . import GitTextCommand, GitWindowCommand, do_when, goto_xy, git_root, get_
 
 
 class GitDiff (object):
-    def run(self, edit=None, ignore_whitespace=False):
+    def run(self, edit=None, ignore_whitespace=False, word_diff=False):
         command = ['git', 'diff', '--no-color']
         if ignore_whitespace:
             command.extend(('--ignore-all-space', '--ignore-blank-lines'))
         command.extend(('--', self.get_file_name()))
         self.run_command(command, self.diff_done)
+        if word_diff:
+            command.append('--word-diff')
 
     def diff_done(self, result):
         if not result.strip():
             self.panel("No output")
             return
         s = sublime.load_settings("Git.sublime-settings")
-        syntax = s.get("diff_syntax", "Packages/Diff/Diff.tmLanguage")
+        syntax = s.get("diff_syntax", "Packages/Git/syntax/Git Diff.sublime-syntax")
         if s.get('diff_panel'):
             self.panel(result, syntax=syntax)
         else:
@@ -28,10 +30,12 @@ class GitDiff (object):
 
 
 class GitDiffCommit (object):
-    def run(self, edit=None, ignore_whitespace=False):
+    def run(self, edit=None, ignore_whitespace=False, word_diff=False):
         command = ['git', 'diff', '--cached', '--no-color']
         if ignore_whitespace:
             command.extend(('--ignore-all-space', '--ignore-blank-lines'))
+        if word_diff:
+            command.extend('--word-diff')
         self.run_command(command, self.diff_done)
 
     def diff_done(self, result):
@@ -39,7 +43,7 @@ class GitDiffCommit (object):
             self.panel("No output")
             return
         s = sublime.load_settings("Git.sublime-settings")
-        syntax = s.get("diff_syntax", "Packages/Diff/Diff.tmLanguage")
+        syntax = s.get("diff_syntax", "Packages/Git/syntax/Git Diff.sublime-syntax")
         self.scratch(result, title="Git Diff", syntax=syntax)
 
 

--- a/syntax/Git Diff.sublime-syntax
+++ b/syntax/Git Diff.sublime-syntax
@@ -1,0 +1,71 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: Git Diff
+file_extensions:
+  - diff
+  - patch
+first_line_match: |-
+  (?x)^
+      (===\ modified\ file
+      |==== \s* // .+ \s - \s .+ \s+ ====
+      |Index:[ ]
+      |---\ [^%]
+      |\*\*\*.*\d{4}\s*$
+      |\d+(,\d+)* (a|d|c) \d+(,\d+)* $
+      |diff\ --git[ ]
+      )
+
+scope: source.diff
+contexts:
+  main:
+    - match: '^((\*{15})|(={67})|(-{3}))$\n?'
+      scope: meta.separator.diff
+      captures:
+        1: punctuation.definition.separator.diff
+    - match: ^\d+(,\d+)*(a|d|c)\d+(,\d+)*$\n?
+      scope: meta.diff.range.normal
+    - match: ^(@@)\s*(.+?)\s*(@@)($\n?)?
+      scope: meta.diff.range.unified
+      captures:
+        1: punctuation.definition.range.diff
+        2: meta.toc-list.line-number.diff
+        3: punctuation.definition.range.diff
+    - match: '^(((\-{3}) .+ (\-{4}))|((\*{3}) .+ (\*{4})))$\n?'
+      scope: meta.diff.range.context
+      captures:
+        3: punctuation.definition.range.diff
+        4: punctuation.definition.range.diff
+        6: punctuation.definition.range.diff
+        7: punctuation.definition.range.diff
+    - match: '(^(((-{3}) .+)|((\*{3}) .+))$\n?|^(={4}) .+(?= - ))'
+      scope: meta.diff.header.from-file
+      captures:
+        4: punctuation.definition.from-file.diff
+        6: punctuation.definition.from-file.diff
+        7: punctuation.definition.from-file.diff
+    - match: '(^(\+{3}) .+$\n?| (-) .* (={4})$\n?)'
+      scope: meta.diff.header.to-file
+      captures:
+        2: punctuation.definition.to-file.diff
+        3: punctuation.definition.to-file.diff
+        4: punctuation.definition.to-file.diff
+    - match: ^(((>)( .*)?)|((\+).*))$\n?
+      scope: markup.inserted.diff
+      captures:
+        3: punctuation.definition.inserted.diff
+        6: punctuation.definition.inserted.diff
+    - match: ^(((<)( .*)?)|((-).*))$\n?
+      scope: markup.deleted.diff
+      captures:
+        3: punctuation.definition.inserted.diff
+        6: punctuation.definition.inserted.diff
+    - match: ^Index(:) (.+)$\n?
+      scope: meta.diff.index
+      captures:
+        1: punctuation.separator.key-value.diff
+        2: meta.toc-list.file-name.diff
+    - match: \{\+.+?\+\}
+      scope: markup.inserted.diff
+    - match: \[\-.+?\-\]
+      scope: markup.deleted.diff


### PR DESCRIPTION
INFO: This PR is just a rebased #468 

- Changed `Diff.tmLanguage` usage to `Git Diff.sublime-syntax`
- Added support for `--word-diff` to previous mentioned syntax

All credits to [@whopil](https://github.com/whophil), I did mostly nothing.

---

To anyone interested in using this feature whilst PR is up, you may go to the package dir,

- Linux: `~/.config/sublime-text-3/Packages/`
- macOS: `~/Library/Application\ Support/Sublime\ Text\ 3/Packages`
- Windows:` %APPDATA%\Sublime Text 3\Packages`

and then drop this repo. Either through manual download or clone it, eg.

```git clone https://github.com/damiannmm/sublime-text-git.git Git```