### PR TITLE
Use per-view settings for git/gitk/flow_command

### DIFF
--- a/git/__init__.py
+++ b/git/__init__.py
@@ -273,20 +273,16 @@ class GitCommand(object):
         ):
             self.active_view().run_command('save')
         if command[0] == 'git':
-            if command[1] == 'flow' and s.get('git_flow_command'):
-                command[0] = s.get('git_flow_command')
+            if command[1] == 'flow' and (self.active_view().settings().get('git_flow_command') if self.active_view() else s.get('git_flow_command')):
+                command[0] = self.active_view().settings().get('git_flow_command') if self.active_view() else s.get('git_flow_command')
                 del(command[1])
             else:
-                us = sublime.load_settings('Preferences.sublime-settings')
-                if s.get('git_command') or us.get('git_binary'):
-                    command[0] = s.get('git_command') or us.get('git_binary')
-                elif GIT:
-                    command[0] = GIT
-        if command[0] == 'gitk' and s.get('gitk_command'):
-            if s.get('gitk_command'):
-                command[0] = s.get('gitk_command')
-            elif GITK:
-                command[0] = GITK
+                command[0] = ( \
+                    (self.active_view().settings().get('git_command') or self.active_view().settings().get('git_binary')) if self.active_view() else \
+                    (s.get('git_command') or sublime.load_settings('Preferences.sublime-settings').get('git_binary')) \
+                ) or GIT
+        if command[0] == 'gitk' and (self.active_view().settings().get('gitk_command') if self.active_view() else s.get('gitk_command')):
+            command[0] = (self.active_view().settings().get('gitk_command') if self.active_view() else s.get('gitk_command')) or GITK
         if not callback:
             callback = self.generic_done
 


### PR DESCRIPTION
Git (well `git` in general, but Git is a big culprit here to try to run `git status` constantly) on a SMB share with a 45k-file repo, most of which symlinks, is Not a good experience. smbd pegged to 100%, constant interference with locks.

This allows overriding the settings per-project, like all settings in https://jisaacks.github.io/GitGutter/settings/

In general, I'd love an equivalent for just disabling all plugin functionality per view like `"git_gutter_enable": false` does, or to set a glob like for indexing to never run Git on remote mountpoints, but setting `"git_command": ["/bin/true"]` in `.sublime-project` suffices, so meh.